### PR TITLE
Don't print error because of not being running in cloudcast instance

### DIFF
--- a/src/Service/OrbitService.cpp
+++ b/src/Service/OrbitService.cpp
@@ -48,6 +48,15 @@ void PrintInstanceVersions() {
   }
 
   {
+    constexpr const char* kCloudcastDirPath = "/usr/local/cloudcast";
+    if (!std::filesystem::is_directory(kCloudcastDirPath))
+    {
+      ORBIT_LOG("Not running in cloudcast instance");
+      return;
+    }
+  }
+
+  {
     constexpr const char* kVersionFilePath = "/usr/local/cloudcast/VERSION";
     ErrorMessageOr<std::string> version = orbit_base::ReadFileToString(kVersionFilePath);
     if (version.has_value()) {


### PR DESCRIPTION
Now prints this:

```
[2026-01-08T00:55:26.667783] [             Service/OrbitService.cpp:54] Not running in cloudcast instance
```

Instead of this:

```
[2026-01-08T00:41:59.179286] [             Service/OrbitService.cpp:56] Error: Unable to open file "/usr/local/cloudcast/VERSION": No such file or directory
[2026-01-08T00:41:59.179322] [             Service/OrbitService.cpp:66] Error: Unable to open file "/usr/local/cloudcast/BASE_VERSION": No such file or directory
[2026-01-08T00:41:59.179347] [             Service/OrbitService.cpp:76] Error: Unable to open file "/usr/local/cloudcast/INSTANCE_VERSION": No such file or directory
sh: 1: /usr/local/cloudcast/bin/gpuinfo: not found
[2026-01-08T00:41:59.180637] [             Service/OrbitService.cpp:90] Error: Could not execute "/usr/local/cloudcast/bin/gpuinfo driver-version"
```