### PR TITLE
Add hosted HTML architecture manual and deep audit

### DIFF
--- a/docs/manual/README.md
+++ b/docs/manual/README.md
@@ -1,0 +1,15 @@
+# Orbit architecture manual
+
+Self-contained HTML manual and architecture review of this repository.
+
+Open [`index.html`](index.html) in a browser, or serve this directory as a static site:
+
+```
+python3 -m http.server --directory docs/manual 8080
+```
+
+Relative links only. No CDN, no webfonts, no external images.
+
+GitHub Pages: set the site source to `/docs` and open `/manual/`, or publish this folder as the site root.
+
+The pages review the code as of the commit that added them. They do not change profiler behavior.

--- a/docs/manual/architecture.html
+++ b/docs/manual/architecture.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Orbit field manual — Architecture</title>
+<style>
+:root{--paper:#f3eee4;--paper-2:#e8e0d0;--ink:#1c1914;--mute:#5c564c;--copper:#9a3f1a;--copper-2:#c4622d;--teal:#1a4f4c;--teal-2:#2d7a74;--navy:#161b27;--navy-2:#232a3a;--code:#e8e0d0;--warn:#f4e0c4;--audit:#ead6cc;--note:#d7e6e2;--line:#cfc4b0;--rail:17.4rem}
+*{box-sizing:border-box}html{scroll-behavior:smooth}
+body{margin:0;background:var(--paper);color:var(--ink);font:16.5px/1.58 "Iowan Old Style","Palatino Linotype",Palatino,"Book Antiqua",Georgia,serif}
+.skip{position:absolute;left:-999px}.skip:focus{left:1rem;top:1rem;background:#fff;padding:.4rem;z-index:2}
+.shell{display:flex;min-height:100vh}
+.rail{width:var(--rail);flex:0 0 var(--rail);background:var(--navy);color:#d9d2c4;padding:1.35rem 1.05rem 2rem;position:sticky;top:0;height:100vh;overflow:auto}
+.rail .brand{color:#f3eee4;text-decoration:none;font:700 1.12rem/1.25 ui-sans-serif,system-ui,sans-serif;letter-spacing:.03em;display:block}
+.rail .brand span{color:var(--copper-2)}
+.rail .tag{font:12px/1.4 ui-sans-serif,system-ui,sans-serif;color:#9a9284;margin:.45rem 0 1.15rem}
+.rail ol{list-style:none;margin:0;padding:0}
+.rail a{display:block;color:#cfc6b6;text-decoration:none;padding:.36rem .5rem;border-left:3px solid transparent;font:13.5px/1.35 ui-sans-serif,system-ui,sans-serif}
+.rail a:hover{color:#fff;background:var(--navy-2)}
+.rail a.current{color:#fff;border-left-color:var(--copper-2);background:var(--navy-2)}
+.rail .num{color:var(--copper-2);margin-right:.35rem;font-variant-numeric:tabular-nums}
+main{flex:1;max-width:54rem;padding:2.1rem 2.3rem 4rem}
+h1,h2,h3,h4{font-family:ui-sans-serif,system-ui,"Segoe UI",sans-serif;letter-spacing:-.02em;line-height:1.25}
+h1{font-size:2.05rem;margin:0 0 .35rem;color:var(--navy)}
+h2{font-size:1.32rem;margin:2.1rem 0 .65rem;padding-top:.55rem;border-top:1px solid var(--line);color:var(--copper)}
+h3{font-size:1.06rem;margin:1.45rem 0 .45rem;color:var(--teal)}
+.lede{font-size:1.12rem;color:var(--mute)}
+.kicker{font:700 .7rem/1 ui-sans-serif,system-ui,sans-serif;letter-spacing:.16em;text-transform:uppercase;color:var(--copper);margin:0 0 .55rem}
+code,pre{font-family:ui-monospace,"SFMono-Regular",Menlo,Consolas,monospace;font-size:.86em}
+code{background:var(--paper-2);padding:.07em .32em;border-radius:3px}
+pre{background:var(--navy);color:var(--code);padding:1rem 1.1rem;overflow:auto;border-radius:4px;line-height:1.45}
+pre code{background:none;padding:0;color:inherit}
+.figure{background:var(--navy);border-radius:6px;padding:1rem 1rem .55rem;margin:1.15rem 0 1.5rem}
+.figure figcaption{color:#9a9284;font:12.5px/1.4 ui-sans-serif,system-ui,sans-serif;margin-top:.45rem}
+.callout{border-left:4px solid var(--teal-2);background:var(--note);padding:.75rem 1rem;margin:1.05rem 0}
+.callout.warn{border-color:var(--copper);background:var(--warn)}
+.callout.audit{border-color:#7a2e1a;background:var(--audit)}
+.callout strong{font-family:ui-sans-serif,system-ui,sans-serif}
+table{border-collapse:collapse;width:100%;font-size:.92rem;margin:1rem 0 1.35rem}
+th,td{border-bottom:1px solid var(--line);padding:.42rem .48rem;text-align:left;vertical-align:top}
+th{font:700 .72rem/1.3 ui-sans-serif,system-ui,sans-serif;text-transform:uppercase;letter-spacing:.06em;color:var(--mute)}
+.pager{display:flex;justify-content:space-between;gap:1rem;margin-top:2.4rem;padding-top:1rem;border-top:1px solid var(--line);font:14px/1.4 ui-sans-serif,system-ui,sans-serif}
+.pager a{color:var(--teal)}
+ul,ol{padding-left:1.2rem}li{margin:.26rem 0}
+a{color:var(--teal)}
+@media(max-width:860px){.shell{display:block}.rail{position:relative;height:auto;width:auto}}
+</style>
+</head>
+<body>
+<a class="skip" href="#main">Skip to content</a>
+<div class="shell">
+<aside class="rail" aria-label="Manual">
+  <a class="brand" href="index.html">Orbit <span>field manual</span></a>
+  <p class="tag">Architecture + audit<br>tree at <code>96b2714</code></p>
+  <ol>
+    <li><a href="index.html"><span class="num">01</span>Overview</a></li>
+    <li><a class="current" href="architecture.html"><span class="num">02</span>Architecture</a></li>
+    <li><a href="linux-tracing.html"><span class="num">03</span>Linux tracing</a></li>
+    <li><a href="instrumentation.html"><span class="num">04</span>Instrumentation</a></li>
+    <li><a href="client-ui.html"><span class="num">05</span>Client UI</a></li>
+    <li><a href="symbols-modules.html"><span class="num">06</span>Symbols &amp; modules</a></li>
+    <li><a href="kernel-assumptions.html"><span class="num">07</span>Kernel assumptions</a></li>
+    <li><a href="audit.html"><span class="num">08</span>Audit</a></li>
+    <li><a href="roadmap.html"><span class="num">09</span>Roadmap</a></li>
+  </ol>
+</aside>
+<main id="main">
+<p class="kicker">Processes · capture pipeline · data flow</p>
+<h1>Architecture</h1>
+<p class="lede">Orbit is a two-process product plus the target. The UI never opens <code>perf_event_open</code>. The service never draws a track. A third channel exists for in-process producers that cannot go through the UI.</p>
+
+<h2>The three processes</h2>
+<h3>Orbit (UI)</h3>
+<p>Entry is <code>src/Orbit/main.cpp</code>. Qt chrome lives in <code>src/OrbitQt</code> (<code>orbitmainwindow.cpp</code>, capture options, connection dialogs). The capture canvas, tracks, and session state live in <code>src/OrbitGl</code>: <code>OrbitApp</code>, <code>TimeGraph</code>, <code>TrackManager</code>, <code>SymbolLoader</code>. <code>OrbitApp</code> is the god object; comments in <code>OrbitApp.h</code> already ask to peel controllers off it.</p>
+<p>The UI talks to the service through generated gRPC stubs in <code>src/GrpcProtos</code>. Default port is <strong>44765</strong> (<code>FLAGS_grpc_port</code> in <code>src/ClientFlags/ClientFlags.cpp</code> and <code>src/Service/main.cpp</code>). The server binds <code>127.0.0.1</code> with <code>InsecureServerCredentials</code> (<code>OrbitGrpcServerImpl::Init</code>). Remote use is an SSH tunnel, not TLS.</p>
+
+<h3>OrbitService</h3>
+<p><code>src/Service/OrbitService.cpp</code> starts the gRPC server and, unless <code>--producer_side_server=false</code>, a second server on the producer-side Unix socket. On Linux, <code>OrbitGrpcServer.cpp</code> registers:</p>
+<ul>
+  <li><code>LinuxCaptureService</code> — bidirectional <code>Capture</code> stream</li>
+  <li><code>ProcessServiceImpl</code> — process list, modules, debug-info path, process memory</li>
+  <li><code>TracepointServiceImpl</code> — enumerate kernel tracepoints</li>
+  <li><code>CrashServiceImpl</code> — only if <code>dev_mode</code></li>
+</ul>
+<p>On Windows the same process registers <code>WindowsCaptureService</code> and <code>WindowsProcessService</code>. There is no Windows tracepoint or crash service in that file.</p>
+<p>At startup on Linux, <code>PrintInstanceVersions</code> runs <code>uname -a</code> and then tries four Stadia/cloudcast paths (<code>/usr/local/cloudcast/VERSION</code>, <code>BASE_VERSION</code>, <code>INSTANCE_VERSION</code>, and <code>/usr/local/cloudcast/bin/gpuinfo</code>). Failures are logged as errors on every ordinary Linux box. See the <a href="audit.html">audit</a>.</p>
+
+<h3>Target + optional in-process producers</h3>
+<p>The target is identified by pid in <code>CaptureOptions</code>. User-space instrumentation injects <code>liborbituserspaceinstrumentation.so</code> and overwrites prologues. The Orbit API (<code>src/Api</code>, enabled via <code>ApiLoader/EnableInTracee.h</code>) and the Vulkan layer (<code>src/OrbitVulkanLayer</code>) connect as producers to <code>unix:/tmp/orbit-producer-side-socket</code> (<code>src/ProducerSideChannel/include/ProducerSideChannel/ProducerSideChannel.h</code>).</p>
+
+<h2>How the UI finds the service</h2>
+<table>
+  <thead><tr><th>Path</th><th>Code</th><th>What happens</th></tr></thead>
+  <tbody>
+    <tr><td>Local</td><td><code>ConnectToLocalWidget</code></td><td>gRPC channel to <code>127.0.0.1:&lt;grpc_port&gt;</code>. Caller must already be running <code>OrbitService</code> (typically as root).</td></tr>
+    <tr><td>SSH / remote</td><td><code>ServiceDeployManager</code></td><td>SFTP-deploys the collector (unless <code>--nodeploy</code>), starts it remotely, opens an SSH tunnel for 44765.</td></tr>
+    <tr><td>Connect-to-target flags</td><td><code>ClientFlags.cpp</code> SSH flags</td><td>Skip the dialog; connect and optionally select <code>--ssh_target_process</code>.</td></tr>
+  </tbody>
+</table>
+<p><code>ServiceDeployManager::Exec</code> is the deploy + tunnel entry. <code>--collector</code> and <code>--collector_root_password</code> are leftover “instance” knobs from the Stadia workflow.</p>
+
+<h2>Capture start / stop</h2>
+<figure class="figure" aria-label="Capture start and stop">
+<svg viewBox="0 0 720 400" width="100%" height="auto" role="img">
+  <title>Capture start and stop</title>
+  <rect width="720" height="400" fill="#161b27"/>
+  <g fill="#f3eee4" font-family="ui-sans-serif,system-ui,sans-serif" font-size="12">
+    <text x="24" y="28" fill="#c4622d">START (LinuxCaptureServiceBase::DoCapture)</text>
+    <text x="24" y="56">1. Enable Orbit API in tracee (optional)</text>
+    <text x="24" y="78">2. If kUserSpaceInstrumentation: InstrumentationManager::InstrumentProcess</text>
+    <text x="24" y="100">3. Filter successfully patched functions out of CaptureOptions</text>
+    <text x="24" y="122">4. TracingHandler::Start → Tracer::Create → TracerImpl::Start</text>
+    <text x="24" y="144">5. MemoryInfoHandler::Start</text>
+    <text x="24" y="166">6. ProducerSideServer notifies in-process producers</text>
+    <text x="24" y="188">7. Wait for client WritesDone or RSS &gt; 50% of physical RAM</text>
+    <text x="24" y="228" fill="#c4622d">STOP</text>
+    <text x="24" y="256">8. Disable API + UninstrumentProcess (restore prologues)</text>
+    <text x="24" y="278">9. Stop TracingHandler, MemoryInfoHandler, producers in parallel threads</text>
+    <text x="24" y="300">10. TracerImpl::Shutdown closes every perf fd (sequential close)</text>
+    <text x="24" y="322">11. Peek /proc/&lt;pid&gt; and /usr/local/cloudcast/core for crash/minidump</text>
+    <text x="24" y="344">12. FinalizeEventProcessing + TerminateCapture</text>
+  </g>
+</svg>
+<figcaption>Sequence is in <code>src/LinuxCaptureService/LinuxCaptureServiceBase.cpp</code> (<code>DoCapture</code>, <code>WaitForStopCaptureRequestOrMemoryThresholdExceeded</code>, <code>StopInternalProducersAndCaptureStartStopListenersInParallel</code>).</figcaption>
+</figure>
+
+<p>The Capture RPC itself is thin: <code>LinuxCaptureService::Capture</code> builds a <code>GrpcClientCaptureEventCollector</code> over the <code>ServerReaderWriter</code>, waits for the first <code>CaptureRequest</code> (the options), then calls <code>DoCapture</code>. A second capture while one is live returns <code>ALREADY_EXISTS</code>.</p>
+
+<div class="callout">
+  <strong>Why stop is parallel at the service layer but serial in the tracer.</strong> Comments in <code>LinuxCaptureServiceBase.cpp</code> say <code>TracingHandler::Stop</code> and producer <code>OnCaptureStopRequested</code> both block, so they are joined on separate threads. Inside the tracer, <code>Shutdown</code> still <code>close()</code>s fds one by one. Parallelizing those closes does not help on current kernels — see <a href="kernel-assumptions.html">kernel assumptions</a>.
+</div>
+
+<h2>Event path: kernel → UI</h2>
+<figure class="figure" aria-label="Event path">
+<svg viewBox="0 0 720 280" width="100%" height="auto" role="img">
+  <title>Event path from kernel to UI</title>
+  <rect width="720" height="280" fill="#161b27"/>
+  <g fill="none" stroke="#c4622d" stroke-width="1.3">
+    <rect x="16" y="40" width="100" height="48" rx="3"/>
+    <rect x="136" y="40" width="110" height="48" rx="3"/>
+    <rect x="266" y="40" width="110" height="48" rx="3"/>
+    <rect x="396" y="40" width="120" height="48" rx="3"/>
+    <rect x="536" y="40" width="168" height="48" rx="3"/>
+    <rect x="16" y="140" width="210" height="48" rx="3"/>
+    <rect x="246" y="140" width="210" height="48" rx="3"/>
+    <rect x="476" y="140" width="228" height="48" rx="3"/>
+  </g>
+  <g fill="#f3eee4" font-family="ui-sans-serif,system-ui,sans-serif" font-size="11">
+    <text x="28" y="68">kernel RB</text>
+    <text x="148" y="68">ProcessOneRecord</text>
+    <text x="278" y="68">DeferEvent</text>
+    <text x="408" y="68">PerfEventProcessor</text>
+    <text x="548" y="68">visitors → TracerListener</text>
+    <text x="28" y="168">TracingHandler::On*</text>
+    <text x="258" y="168">ProducerEventProcessor</text>
+    <text x="488" y="168">gRPC CaptureResponse → UI</text>
+    <text x="16" y="220" fill="#9a9284">User-space FunctionEntry/Exit are hijacked back into TracerImpl so unwinding sees them like uretprobes.</text>
+  </g>
+  <g stroke="#2d7a74" stroke-width="1.5" fill="none">
+    <path d="M116 64 H136"/><path d="M246 64 H266"/><path d="M376 64 H396"/><path d="M516 64 H536"/>
+    <path d="M620 88 V140"/><path d="M620 140 H581"/><path d="M476 164 H456"/><path d="M246 164 H226"/>
+  </g>
+</svg>
+<figcaption>Ring-buffer records become <code>PerfEvent</code>s, reordered with a 333&nbsp;ms delay (<code>PerfEventProcessor::kProcessingDelayMs</code>), then protobuf <code>ProducerCaptureEvent</code>s on the capture stream.</figcaption>
+</figure>
+
+<p>User-space instrumentation does not emit timers on its own path into the UI. <code>ProducerEventProcessorHijackingFunctionEntryExitForLinuxTracing</code> intercepts <code>FunctionEntry</code> / <code>FunctionExit</code> and calls <code>TracingHandler::ProcessFunctionEntry/Exit</code>, which forwards into <code>TracerImpl</code>. <code>UprobesFunctionCallManager</code> then builds the same <code>FunctionCall</code> objects it would for uretprobes. That is why trampolines and uprobes can share the unwinder and the call-stack patching logic.</p>
+
+<h2>gRPC surface</h2>
+<p>Protos live under <code>src/GrpcProtos/</code>. The capture contract is <code>capture.proto</code>. <code>CaptureOptions</code> (next id 23 in the comment, with later Python fields at 24+) is the one large message: pid, sample rate, stack dump size, unwinding method, dynamic-instrumentation method, instrumented functions, Wine helpers, GPU flag, memory sampling, API functions, thread-state callstack policy, Python flags.</p>
+<p>The receive size on the server is <code>INT32_MAX</code> so an unbounded options message can arrive. There is no authn/authz on the channel.</p>
+
+<h2>Producer-side channel</h2>
+<p><code>ProducerSideServer</code> implements <code>CaptureStartStopListener</code>. On capture start it is given the hijacking processor so API scopes from the injected library and Vulkan debug markers join the same stream. Socket path: <code>/tmp/orbit-producer-side-socket</code>. Windows uses <code>localhost:1789</code> instead. The injected user-space library calls <code>CreateProducerSideChannel()</code> from <code>OrbitUserSpaceInstrumentation.cpp</code>.</p>
+
+<h2>Memory watchdog</h2>
+<p><code>WaitForStopCaptureRequestOrMemoryThresholdExceeded</code> polls OrbitService RSS every second via <code>/proc/self/stat</code> field 24 (<code>MemoryWatchdog.cpp</code>). Threshold is <strong>half of physical RAM</strong> (<code>kMemTotalBytes / 2</code>). Crossing it stops the capture with <code>StopCaptureReason::kMemoryWatchdog</code>. This is a service-side safety net, not a UI setting (the UI has a separate, flag-gated warning-threshold checkbox).</p>
+
+<h2>Windows path (what exists)</h2>
+<p><code>WindowsCaptureService::Capture</code> enables the API in the tracee, starts <code>WindowsTracing::TracerImpl</code> (krabsetw ETW: sampling + modules + thread names), notifies producers, waits for stop, disables the API, stops the tracer. There is no <code>InstrumentationManager</code>, no uprobes, no sched tracepoints, no memory watchdog loop like Linux. <code>WindowsTracing/TracerImpl.cpp</code> is short: snapshot modules (Toolhelp, fallback ETW), snapshot thread names, run <code>KrabsTracer</code>.</p>
+
+<h2>Capture file</h2>
+<p>On-disk format is documented in <code>src/CaptureFile/FORMAT.md</code>: 4-byte signature <code>ORBT</code>, version, capture-section offset, optional extra sections, optional user-data section. The capture section is a sequence of <code>ClientCaptureEvent</code> messages starting with <code>CaptureStarted</code> and ending with <code>CaptureFinished</code>. The UI can reload a file without a service.</p>
+
+<div class="callout audit">
+  <strong>Stadia-shaped stop.</strong> After stop, <code>GetTargetProcessStateAfterCapture</code> looks for minidumps matching <code>.*&lt;pid&gt;.&lt;epoch&gt;.core.dmp</code> under <code>/usr/local/cloudcast/core</code>. On a machine without that directory the function either reports “still running”, “ended”, or an internal error — never a Stadia crash. Comments still mention <code>CloudCollectorStartStopCaptureRequestWaiter</code>, which is not a type in this tree.
+</div>
+
+<nav class="pager">
+  <a href="index.html">← Overview</a>
+  <a href="linux-tracing.html">Linux tracing →</a>
+</nav>
+</main>
+</div>
+</body>
+</html>

--- a/docs/manual/audit.html
+++ b/docs/manual/audit.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Orbit field manual — Audit</title>
+<style>
+:root{--paper:#f3eee4;--paper-2:#e8e0d0;--ink:#1c1914;--mute:#5c564c;--copper:#9a3f1a;--copper-2:#c4622d;--teal:#1a4f4c;--teal-2:#2d7a74;--navy:#161b27;--navy-2:#232a3a;--code:#e8e0d0;--warn:#f4e0c4;--audit:#ead6cc;--note:#d7e6e2;--line:#cfc4b0;--rail:17.4rem}
+*{box-sizing:border-box}html{scroll-behavior:smooth}
+body{margin:0;background:var(--paper);color:var(--ink);font:16.5px/1.58 "Iowan Old Style","Palatino Linotype",Palatino,"Book Antiqua",Georgia,serif}
+.skip{position:absolute;left:-999px}.skip:focus{left:1rem;top:1rem;background:#fff;padding:.4rem;z-index:2}
+.shell{display:flex;min-height:100vh}
+.rail{width:var(--rail);flex:0 0 var(--rail);background:var(--navy);color:#d9d2c4;padding:1.35rem 1.05rem 2rem;position:sticky;top:0;height:100vh;overflow:auto}
+.rail .brand{color:#f3eee4;text-decoration:none;font:700 1.12rem/1.25 ui-sans-serif,system-ui,sans-serif;letter-spacing:.03em;display:block}
+.rail .brand span{color:var(--copper-2)}
+.rail .tag{font:12px/1.4 ui-sans-serif,system-ui,sans-serif;color:#9a9284;margin:.45rem 0 1.15rem}
+.rail ol{list-style:none;margin:0;padding:0}
+.rail a{display:block;color:#cfc6b6;text-decoration:none;padding:.36rem .5rem;border-left:3px solid transparent;font:13.5px/1.35 ui-sans-serif,system-ui,sans-serif}
+.rail a:hover{color:#fff;background:var(--navy-2)}
+.rail a.current{color:#fff;border-left-color:var(--copper-2);background:var(--navy-2)}
+.rail .num{color:var(--copper-2);margin-right:.35rem;font-variant-numeric:tabular-nums}
+main{flex:1;max-width:54rem;padding:2.1rem 2.3rem 4rem}
+h1,h2,h3,h4{font-family:ui-sans-serif,system-ui,"Segoe UI",sans-serif;letter-spacing:-.02em;line-height:1.25}
+h1{font-size:2.05rem;margin:0 0 .35rem;color:var(--navy)}
+h2{font-size:1.32rem;margin:2.1rem 0 .65rem;padding-top:.55rem;border-top:1px solid var(--line);color:var(--copper)}
+h3{font-size:1.06rem;margin:1.45rem 0 .45rem;color:var(--teal)}
+.lede{font-size:1.12rem;color:var(--mute)}
+.kicker{font:700 .7rem/1 ui-sans-serif,system-ui,sans-serif;letter-spacing:.16em;text-transform:uppercase;color:var(--copper);margin:0 0 .55rem}
+code,pre{font-family:ui-monospace,"SFMono-Regular",Menlo,Consolas,monospace;font-size:.86em}
+code{background:var(--paper-2);padding:.07em .32em;border-radius:3px}
+pre{background:var(--navy);color:var(--code);padding:1rem 1.1rem;overflow:auto;border-radius:4px;line-height:1.45}
+pre code{background:none;padding:0;color:inherit}
+.figure{background:var(--navy);border-radius:6px;padding:1rem 1rem .55rem;margin:1.15rem 0 1.5rem}
+.figure figcaption{color:#9a9284;font:12.5px/1.4 ui-sans-serif,system-ui,sans-serif;margin-top:.45rem}
+.callout{border-left:4px solid var(--teal-2);background:var(--note);padding:.75rem 1rem;margin:1.05rem 0}
+.callout.warn{border-color:var(--copper);background:var(--warn)}
+.callout.audit{border-color:#7a2e1a;background:var(--audit)}
+.callout strong{font-family:ui-sans-serif,system-ui,sans-serif}
+table{border-collapse:collapse;width:100%;font-size:.92rem;margin:1rem 0 1.35rem}
+th,td{border-bottom:1px solid var(--line);padding:.42rem .48rem;text-align:left;vertical-align:top}
+th{font:700 .72rem/1.3 ui-sans-serif,system-ui,sans-serif;text-transform:uppercase;letter-spacing:.06em;color:var(--mute)}
+.pager{display:flex;justify-content:space-between;gap:1rem;margin-top:2.4rem;padding-top:1rem;border-top:1px solid var(--line);font:14px/1.4 ui-sans-serif,system-ui,sans-serif}
+.pager a{color:var(--teal)}
+ul,ol{padding-left:1.2rem}li{margin:.26rem 0}
+a{color:var(--teal)}
+@media(max-width:860px){.shell{display:block}.rail{position:relative;height:auto;width:auto}}
+</style>
+</head>
+<body>
+<a class="skip" href="#main">Skip to content</a>
+<div class="shell">
+<aside class="rail" aria-label="Manual">
+  <a class="brand" href="index.html">Orbit <span>field manual</span></a>
+  <p class="tag">Architecture + audit<br>tree at <code>96b2714</code></p>
+  <ol>
+    <li><a href="index.html"><span class="num">01</span>Overview</a></li>
+    <li><a href="architecture.html"><span class="num">02</span>Architecture</a></li>
+    <li><a href="linux-tracing.html"><span class="num">03</span>Linux tracing</a></li>
+    <li><a href="instrumentation.html"><span class="num">04</span>Instrumentation</a></li>
+    <li><a href="client-ui.html"><span class="num">05</span>Client UI</a></li>
+    <li><a href="symbols-modules.html"><span class="num">06</span>Symbols &amp; modules</a></li>
+    <li><a href="kernel-assumptions.html"><span class="num">07</span>Kernel assumptions</a></li>
+    <li><a class="current" href="audit.html"><span class="num">08</span>Audit</a></li>
+    <li><a href="roadmap.html"><span class="num">09</span>Roadmap</a></li>
+  </ol>
+</aside>
+<main id="main">
+<p class="kicker">Shortcomings · leftovers · tests · footguns</p>
+<h1>Audit</h1>
+<p class="lede">This is a reading of the tree, not a load test. Items below are things the code actually does (or does not do). Severity is about user impact on a current Linux box, not about elegance.</p>
+
+<h2>What this review could not do</h2>
+<ul>
+  <li>No <code>OrbitQt</code> build — Qt5 packages were not present.</li>
+  <li>No <code>LinuxTracing</code> build — gRPC/protobuf/LLVM/Conan graph not installed; py-spy FFI needs Cargo.</li>
+  <li>No <code>perf_event_open</code> of an uprobe — no PMU, no <code>uprobe_events</code>.</li>
+  <li>No integration tests, no <code>ORBIT_UPROBE_BENCH=1</code>. <strong>No milliseconds claimed.</strong></li>
+  <li>PR #10 inspected via <code>git log</code> / <code>git diff --stat</code> against <code>main</code>, not merged.</li>
+</ul>
+
+<h2>High-impact shortcomings</h2>
+<h3>1. Uprobe stop scales with cores × functions</h3>
+<p>Current <code>OpenUprobes</code> + sequential <code>close</code> is the product’s most expensive teardown. User-space instrumentation is the default partly because of this (the UI literally says uprobes are “slower”). On a 16–32 CPU machine with dozens of hooks, stop can dominate the session. The fix direction is already designed on <code>cursor/fast-uprobe-stop-a3cf</code>. Leaving it unmerged is a product bug, not a research gap.</p>
+
+<h3>2. Tracepoint IDs are debugfs-only</h3>
+<p><code>GetTracepointId</code> will not see a modern-only tracefs mount. Scheduling, thread names, GPU, and custom tracepoints then fail together. Easy to fix; unfixed for years.</p>
+
+<h3>3. <code>uprobe_type()</code> / <code>max_stack()</code> can throw</h3>
+<p>Static initialization via <code>ReadFileToString().value()</code> + <code>std::stoul</code> is not an <code>ErrorMessageOr</code>. A container kernel without the PMU can abort the tracer thread instead of emitting the existing protobuf error event.</p>
+
+<h3>4. CI does not run the tests that need a real kernel</h3>
+<p><code>.github/workflows/build-and-test.yml</code> Ubuntu step:</p>
+<pre><code>ARGS="-E IntegrationTest" ... cmake --build . --target test</code></pre>
+<p>So <code>LinuxTracingIntegrationTests</code> and <code>OrbitServiceIntegrationTests</code> never run on GitHub Actions. GPU tests also require <code>CheckIsStadiaInstance()</code> (kernel release contains <code>-ggp-</code>). Unit tests cannot replace “did <code>perf_event_open</code> actually fire?”. A regression in <code>OpenUprobes</code> can merge green.</p>
+<p>Ubuntu CI also configures CMake <em>without</em> Conan (system packages). The README’s happy path is Conan 2. Windows CI still pins Conan <strong>1.58.0</strong>. Three build stories, one repo. Actions still use <code>checkout@v3</code> / <code>cache@v3</code> / <code>upload-artifact@v3</code>.</p>
+
+<h3>5. Integration tests skip the interesting cases</h3>
+<table>
+  <thead><tr><th>Test</th><th>Gate</th></tr></thead>
+  <tbody>
+    <tr><td><code>SchedulingSlices</code></td><td>root</td></tr>
+    <tr><td><code>FunctionCalls</code></td><td>root (uprobes)</td></tr>
+    <tr><td><code>CallstackSamplesAndAddressInfos</code></td><td>paranoid ≤ 0</td></tr>
+    <tr><td><code>CallstackSamplesTogetherWithFunctionCalls</code></td><td>root</td></tr>
+    <tr><td><code>CallstackSamplesWithFramePointers</code></td><td>paranoid ≤ 0</td></tr>
+    <tr><td><code>CallstackSamplesWithFramePointersTogetherWithFunctionCalls</code></td><td>root</td></tr>
+    <tr><td><code>ThreadStateSlices</code></td><td>root</td></tr>
+    <tr><td><code>ThreadNames</code></td><td>root</td></tr>
+    <tr><td><code>ModuleUpdateOnDlopen</code></td><td>paranoid ≤ 0</td></tr>
+    <tr><td><code>GpuJobs</code></td><td>Stadia instance <em>and</em> root</td></tr>
+  </tbody>
+</table>
+<p><code>OnThreadStateSliceCallstack</code> in the test listener is a no-op with <code>TODO(b/243515756)</code>. Thread-state slices in the test expect <code>pid == 0</code> (“We currently don’t set the pid”). User-space instrumentation has a separate service-level test that also skips without root. There is no test that a function failing user-space patch is actually opened as a uprobe.</p>
+
+<h2>Poor implementation / footguns</h2>
+<ul>
+  <li><strong>Partial uprobe success.</strong> <code>OpenUserSpaceProbes</code> continues after a failed function, sets a boolean, and still enables the fds that worked. The UI gets a generic “uprobes” failure string, not per-function errors (those exist only for the “not in a file mapping” warning).</li>
+  <li><strong>ioctl / close errors ignored.</strong> <code>perf_event_enable/disable/redirect</code> log and proceed. <code>close</code> return value is discarded. Teardown can look clean while probes remain.</li>
+  <li><strong>TracingHandler one-shot.</strong> After <code>Stop</code>, late <code>FunctionEntry</code> events are dropped. A second <code>Start</code> on the same object is forbidden by comment, not by API.</li>
+  <li><strong>333&nbsp;ms reorder delay.</strong> Always. Short captures and “stop and see the last slice” pay it. Not configurable.</li>
+  <li><strong>Python auto-on.</strong> Any exe whose basename contains <code>python</code> gets a py-spy attach (ptrace). That can fail noisily or surprise a user who did not ask. Detection misses embedded interpreters.</li>
+  <li><strong>py-spy FFI build.</strong> <code>LinuxTracing</code> unconditionally <code>PRIVATE pyspy_ffi</code>. If Cargo is missing, CMake warns and <code>return()</code>s from the FFI file — the imported target may not exist and the LinuxTracing configure/link becomes environment-dependent. No test binary covers <code>PythonProfiler</code>.</li>
+  <li><strong>Insecure gRPC on localhost</strong> is fine behind SSH; it is not fine if someone rebinds the flag. There is no peer auth on the Unix producer socket either (filesystem permissions only, <code>/tmp/...</code>).</li>
+  <li><strong>Memory watchdog = 50% of physical RAM.</strong> In a small cgroup this is either never hit or hit immediately. It reads host <code>sysconf(_SC_PHYS_PAGES)</code>, not cgroup memory.max.</li>
+  <li><strong>cgroup v1 only</strong> for cpuset and for memory tracks that still talk about <code>ggp run --enforce-production-ram</code> (<code>CGroupAndProcessMemoryTrack.cpp</code>).</li>
+  <li><strong>Round-robin batch of 5</strong> treats a stack sample like a sched_switch. The TODO in <code>Run</code> admits this. Under load, sampling buffers (16&nbsp;MiB) and uprobe buffers (8&nbsp;MiB) can still <code>LOST</code>.</li>
+  <li><strong>Wine / PE anonymous maps</strong> — uprobes silently do not fire; the warning exists but only if maps were readable at start.</li>
+  <li><strong>ARM64 docs vs code.</strong> <code>building_arm64.md</code> says dynamic instrumentation is “uprobes-based” and unsupported. Code: trampolines unsupported, uprobe PMU wired.</li>
+</ul>
+
+<h2>Stadia / GGP / cloudcast leftovers</h2>
+<p>These still compile and still run on the hot path:</p>
+<ul>
+  <li><code>PrintInstanceVersions</code> — four cloudcast reads + <code>gpuinfo</code> on every service start.</li>
+  <li>Minidump directory <code>/usr/local/cloudcast/core</code> for capture-finished process state.</li>
+  <li><code>src/OrbitClientGgp</code>, <code>OrbitCaptureGgpClient</code>, <code>OrbitCaptureGgpService</code>, <code>services_ggp.proto</code>, port 44767.</li>
+  <li><code>GGP_SDK_PATH</code> symbol provider; <code>ggpvlk.so</code> load priority; FakeClient instruments <code>ggpvlk QueuePresentKHR</code>.</li>
+  <li><code>CheckIsStadiaInstance</code> — GPU integration tests are dead on any non-<code>-ggp-</code> kernel.</li>
+  <li>Comments referring to <code>CloudCollectorStartStopCaptureRequestWaiter</code> (type not in tree).</li>
+  <li><code>copybara:insert</code> blocks in UserSpaceInstrumentation and OrbitBase tests.</li>
+  <li>Toolchain file <code>third_party/toolchains/toolchain-linux-ggp-release.cmake</code>.</li>
+</ul>
+<p>None of this is “wrong” if Stadia support is still a goal. If it is not, it is noise that hides real errors (every laptop start logs four <code>ORBIT_ERROR</code>s from missing VERSION files).</p>
+
+<h2>Windows vs Linux completeness</h2>
+<p>README is accurate. Windows has ETW sampling, module/thread snapshots, optional API-in-tracee. It does not have dynamic hooks, sched tracepoints, uprobes, user-space trampolines, or the Linux memory watchdog. Shipping a Windows UI that talks to Linux OrbitService is the supported remote story. Local Windows profiling is a remnant.</p>
+
+<h2>GPU path assumptions</h2>
+<p>Driver timeline is AMD-only. Vulkan debug markers need <code>src/OrbitVulkanLayer</code> loaded in the target and the producer socket. Tests for GPU jobs are Stadia-gated. Raspberry Pi and Intel/NVIDIA users get a checkbox that fails open.</p>
+
+<h2>Error handling quality (honest summary)</h2>
+<p>The codebase is not sloppy about logging. Almost every <code>perf_event_open</code> failure is <code>ORBIT_ERROR</code>’d. The gap is <em>recovery and specificity</em>: one boolean for “some uprobes failed”, exceptions on missing sysfs, no retry, no capability probe at service start, no structured “this kernel cannot do X” before the user hooks 80 functions.</p>
+<p>Thread safety in the tracer is mostly “one run thread + one deferred thread + mutex on the staging vector.” Visitors are not concurrent. UI <code>OrbitApp</code> hops to the main executor for almost every event — correct, and a bottleneck under huge captures (not measured here).</p>
+
+<h2>Dead or disabled tests elsewhere</h2>
+<p>Several tests are compiled but disabled with Google Orbit issue links: <code>OrbitBase/ThreadPoolTest.cpp</code> (#4503), <code>ObjectUtils/ElfFileTest.cpp</code> (#4502), <code>WindowsUtils/ProcessLauncherTest.cpp</code>. Those are inherited, not introduced here.</p>
+
+<h2>What is actually in good shape</h2>
+<p>Credit where the tree deserves it:</p>
+<ul>
+  <li>Visitor split and 333&nbsp;ms reorder are a clear, documented design — not an accident.</li>
+  <li>User-space and kernel paths sharing <code>UprobesFunctionCallManager</code> is the right abstraction.</li>
+  <li>Wine stack-switch handling is specific and commented.</li>
+  <li>Capture file format is versioned and documented (<code>FORMAT.md</code>).</li>
+  <li>Unit tests around unwind + mmap updates are thorough <em>as fixtures</em>.</li>
+  <li>This fork’s ARM64 register work and py-spy integration are real features, even if the latter is still young.</li>
+</ul>
+
+<nav class="pager">
+  <a href="kernel-assumptions.html">← Kernel assumptions</a>
+  <a href="roadmap.html">Roadmap →</a>
+</nav>
+</main>
+</div>
+</body>
+</html>

--- a/docs/manual/client-ui.html
+++ b/docs/manual/client-ui.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Orbit field manual — Client UI</title>
+<style>
+:root{--paper:#f3eee4;--paper-2:#e8e0d0;--ink:#1c1914;--mute:#5c564c;--copper:#9a3f1a;--copper-2:#c4622d;--teal:#1a4f4c;--teal-2:#2d7a74;--navy:#161b27;--navy-2:#232a3a;--code:#e8e0d0;--warn:#f4e0c4;--audit:#ead6cc;--note:#d7e6e2;--line:#cfc4b0;--rail:17.4rem}
+*{box-sizing:border-box}html{scroll-behavior:smooth}
+body{margin:0;background:var(--paper);color:var(--ink);font:16.5px/1.58 "Iowan Old Style","Palatino Linotype",Palatino,"Book Antiqua",Georgia,serif}
+.skip{position:absolute;left:-999px}.skip:focus{left:1rem;top:1rem;background:#fff;padding:.4rem;z-index:2}
+.shell{display:flex;min-height:100vh}
+.rail{width:var(--rail);flex:0 0 var(--rail);background:var(--navy);color:#d9d2c4;padding:1.35rem 1.05rem 2rem;position:sticky;top:0;height:100vh;overflow:auto}
+.rail .brand{color:#f3eee4;text-decoration:none;font:700 1.12rem/1.25 ui-sans-serif,system-ui,sans-serif;letter-spacing:.03em;display:block}
+.rail .brand span{color:var(--copper-2)}
+.rail .tag{font:12px/1.4 ui-sans-serif,system-ui,sans-serif;color:#9a9284;margin:.45rem 0 1.15rem}
+.rail ol{list-style:none;margin:0;padding:0}
+.rail a{display:block;color:#cfc6b6;text-decoration:none;padding:.36rem .5rem;border-left:3px solid transparent;font:13.5px/1.35 ui-sans-serif,system-ui,sans-serif}
+.rail a:hover{color:#fff;background:var(--navy-2)}
+.rail a.current{color:#fff;border-left-color:var(--copper-2);background:var(--navy-2)}
+.rail .num{color:var(--copper-2);margin-right:.35rem;font-variant-numeric:tabular-nums}
+main{flex:1;max-width:54rem;padding:2.1rem 2.3rem 4rem}
+h1,h2,h3,h4{font-family:ui-sans-serif,system-ui,"Segoe UI",sans-serif;letter-spacing:-.02em;line-height:1.25}
+h1{font-size:2.05rem;margin:0 0 .35rem;color:var(--navy)}
+h2{font-size:1.32rem;margin:2.1rem 0 .65rem;padding-top:.55rem;border-top:1px solid var(--line);color:var(--copper)}
+h3{font-size:1.06rem;margin:1.45rem 0 .45rem;color:var(--teal)}
+.lede{font-size:1.12rem;color:var(--mute)}
+.kicker{font:700 .7rem/1 ui-sans-serif,system-ui,sans-serif;letter-spacing:.16em;text-transform:uppercase;color:var(--copper);margin:0 0 .55rem}
+code,pre{font-family:ui-monospace,"SFMono-Regular",Menlo,Consolas,monospace;font-size:.86em}
+code{background:var(--paper-2);padding:.07em .32em;border-radius:3px}
+pre{background:var(--navy);color:var(--code);padding:1rem 1.1rem;overflow:auto;border-radius:4px;line-height:1.45}
+pre code{background:none;padding:0;color:inherit}
+.figure{background:var(--navy);border-radius:6px;padding:1rem 1rem .55rem;margin:1.15rem 0 1.5rem}
+.figure figcaption{color:#9a9284;font:12.5px/1.4 ui-sans-serif,system-ui,sans-serif;margin-top:.45rem}
+.callout{border-left:4px solid var(--teal-2);background:var(--note);padding:.75rem 1rem;margin:1.05rem 0}
+.callout.warn{border-color:var(--copper);background:var(--warn)}
+.callout.audit{border-color:#7a2e1a;background:var(--audit)}
+.callout strong{font-family:ui-sans-serif,system-ui,sans-serif}
+table{border-collapse:collapse;width:100%;font-size:.92rem;margin:1rem 0 1.35rem}
+th,td{border-bottom:1px solid var(--line);padding:.42rem .48rem;text-align:left;vertical-align:top}
+th{font:700 .72rem/1.3 ui-sans-serif,system-ui,sans-serif;text-transform:uppercase;letter-spacing:.06em;color:var(--mute)}
+.pager{display:flex;justify-content:space-between;gap:1rem;margin-top:2.4rem;padding-top:1rem;border-top:1px solid var(--line);font:14px/1.4 ui-sans-serif,system-ui,sans-serif}
+.pager a{color:var(--teal)}
+ul,ol{padding-left:1.2rem}li{margin:.26rem 0}
+a{color:var(--teal)}
+@media(max-width:860px){.shell{display:block}.rail{position:relative;height:auto;width:auto}}
+</style>
+</head>
+<body>
+<a class="skip" href="#main">Skip to content</a>
+<div class="shell">
+<aside class="rail" aria-label="Manual">
+  <a class="brand" href="index.html">Orbit <span>field manual</span></a>
+  <p class="tag">Architecture + audit<br>tree at <code>96b2714</code></p>
+  <ol>
+    <li><a href="index.html"><span class="num">01</span>Overview</a></li>
+    <li><a href="architecture.html"><span class="num">02</span>Architecture</a></li>
+    <li><a href="linux-tracing.html"><span class="num">03</span>Linux tracing</a></li>
+    <li><a href="instrumentation.html"><span class="num">04</span>Instrumentation</a></li>
+    <li><a class="current" href="client-ui.html"><span class="num">05</span>Client UI</a></li>
+    <li><a href="symbols-modules.html"><span class="num">06</span>Symbols &amp; modules</a></li>
+    <li><a href="kernel-assumptions.html"><span class="num">07</span>Kernel assumptions</a></li>
+    <li><a href="audit.html"><span class="num">08</span>Audit</a></li>
+    <li><a href="roadmap.html"><span class="num">09</span>Roadmap</a></li>
+  </ol>
+</aside>
+<main id="main">
+<p class="kicker">Session · capture view · tracks · Hook</p>
+<h1>Client UI</h1>
+<p class="lede">The client is a Qt5 shell around an immediate-mode-ish OpenGL capture canvas. Almost every product noun — track, hook, preset, sampling report — is a <code>DataView</code> plus a <code>Track</code> plus a pile of state on <code>OrbitApp</code>.</p>
+
+<h2>Session setup</h2>
+<p><code>src/SessionSetup</code> is the connection dialog: local gRPC, SSH deploy, “connect to this process”. <code>ServiceDeployManager</code> copies <code>OrbitService</code> with SFTP, starts it, tunnels 44765. <code>--nodeploy</code> skips the copy. <code>--process_name</code> auto-selects after connect.</p>
+<p>Process list and module list come from <code>ProcessServiceImpl</code> (<code>GetProcessList</code>, <code>GetModuleList</code>, <code>GetDebugInfoFile</code>, <code>GetProcessMemory</code>). The UI does not parse <code>/proc</code> itself when talking to a remote service.</p>
+
+<h2>Main window and capture options</h2>
+<p><code>OrbitMainWindow</code> persists settings in <code>QSettings</code>, including <code>kDynamicInstrumentationMethodSettingKey</code>. Invalid stored values snap back to user-space instrumentation. The options dialog (<code>src/OrbitQt/CaptureOptionsDialog.cpp</code>) is the real catalog of toggles:</p>
+<ul>
+  <li>Sampling on/off is still partially hidden (<code>TODO(b/198748597)</code> — “Don’t hide samplingCheckBox…”).</li>
+  <li>Unwinding: DWARF vs frame pointers. Wine group box enables only for DWARF.</li>
+  <li>Dynamic method: Orbit (user-space) vs kernel uprobes.</li>
+  <li>Thread state, context switches, GPU driver, memory collection, introspection, API.</li>
+  <li>Stack dump size; thread-state callstack collection + dump size.</li>
+</ul>
+<p>Tracepoint picking is behind <code>--enable_tracepoint_feature</code> (default false). Memory warning threshold is behind <code>--enable_warning_threshold</code>. Time-range selection and symbol-store support are also flag-gated defaults-off.</p>
+
+<h2>Capture view and tracks</h2>
+<p><code>TimeGraph</code> owns layout, timeline, sliders, and <code>TrackContainer</code> / <code>TrackManager</code>. <code>ProcessTimer</code> is still on the UI object (<code>TODO(b/214282122)</code>). Tracks that actually exist as classes:</p>
+<table>
+  <thead><tr><th>Track</th><th>Source events</th></tr></thead>
+  <tbody>
+    <tr><td><code>SchedulerTrack</code></td><td><code>SchedulingSlice</code> (sched_switch)</td></tr>
+    <tr><td><code>ThreadTrack</code></td><td>function-call timers, samples, thread-state bar, tracepoint bar</td></tr>
+    <tr><td><code>GpuTrack</code> / <code>GpuSubmissionTrack</code> / <code>GpuDebugMarkerTrack</code></td><td>AMD jobs + Vulkan markers</td></tr>
+    <tr><td><code>FrameTrack</code></td><td>instrumented function used as a frame delimiter</td></tr>
+    <tr><td><code>SystemMemoryTrack</code>, <code>CGroupAndProcessMemoryTrack</code></td><td>memory sampling</td></tr>
+    <tr><td><code>PageFaultsTrack</code> (major/minor)</td><td>page-fault series</td></tr>
+    <tr><td><code>VariableTrack</code>, <code>AsyncTrack</code></td><td>API value tracks / async scopes</td></tr>
+  </tbody>
+</table>
+<p><code>TrackManager::GetOrCreateTrackFromTimerInfo</code> is the factory from a <code>TimerInfo</code>. Visible-track sort prefers tracks that have instrumented timers. There is a long tail of TODOs around track hierarchy, creating tracks only while drawing, and float time-axis precision (<code>b/244736453</code>).</p>
+<p>Thread tracks show samples as ticks and dynamic calls as nested boxes. Filtering of timers is implemented only on <code>ThreadTrack</code> (<code>b/179225487</code>).</p>
+
+<h2>Symbols tab and Functions tab</h2>
+<p>After connect, modules appear in the Symbols data view. <code>SymbolLoader::RetrieveModuleAndLoadSymbols</code> fills them (see <a href="symbols-modules.html">symbols</a>). Successfully loaded symbols populate <code>FunctionsDataView</code>.</p>
+<p>Columns: Hooked, Function, Size, Module, Address in module. Type glyphs include <code>MS</code>/<code>MA</code> (manual sync/async) and <code>D</code> (dynamically instrumented in the last capture). Hook/Unhook and frame-track enable live in the shared <code>DataView</code> context menu and also appear on sampling-report and callstack views so you can hook from a sample.</p>
+
+<h2>Sampling report and call tree</h2>
+<p>Selecting a range on the sampling track builds a <code>SamplingReport</code> (<code>src/OrbitGl/include/OrbitGl/SamplingReport.h</code>). Call tree widgets (<code>CallTreeWidget</code>, <code>CallTreeViewItemModel</code>) default to fully expanded in this fork (recent commit “Make CallTree Widgets fully expand by default”). The call-tree slider is also on by default here.</p>
+
+<h2>Presets</h2>
+<p><code>src/PresetFile</code> plus File → Save Preset. A preset stores hooked function hashes/names per module. Load re-selects via <code>OrbitApp::SelectFunctionsFromHashes</code> / <code>SelectFunctionsByName</code>. This does not persist kernel state; it only restocks the Hook list.</p>
+
+<h2>Keyboard (as documented)</h2>
+<p>The root README is the user-facing map: <kbd>F5</kbd> start/stop, <kbd>W</kbd>/<kbd>S</kbd> or Ctrl+wheel zoom, Ctrl+right-drag zoom-to-range, Ctrl++/− UI scale, Space = last two seconds. Those bindings live in the Qt/GL event handlers (<code>CaptureWindow.cpp</code>, <code>orbitmainwindow.cpp</code>). This review did not click through a running UI.</p>
+
+<h2>Introspection</h2>
+<p>When <code>enable_introspection</code> is on, OrbitService records its own API events and thread states (pid filter includes the service). The UI can also open an <code>IntrospectionWindow</code>. Useful when stop is slow: you can see the collector burning time in <code>Shutdown</code> if introspection was enabled for that capture.</p>
+
+<div class="callout audit">
+  <strong>UI debt that bites users.</strong> <code>DoZoom</code> is still a global. Several tracks copy-paste layout hacks (“Track hierarchy refactor, remove hack below”). <code>OrbitApp</code> still owns symbol loading, capture start, hooking, and frame tracks. None of that is broken in the small, but it is why “just add a track type” is expensive.
+</div>
+
+<nav class="pager">
+  <a href="instrumentation.html">← Instrumentation</a>
+  <a href="symbols-modules.html">Symbols &amp; modules →</a>
+</nav>
+</main>
+</div>
+</body>
+</html>

--- a/docs/manual/index.html
+++ b/docs/manual/index.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Orbit field manual — Overview</title>
+<style>
+:root{--paper:#f3eee4;--paper-2:#e8e0d0;--ink:#1c1914;--mute:#5c564c;--copper:#9a3f1a;--copper-2:#c4622d;--teal:#1a4f4c;--teal-2:#2d7a74;--navy:#161b27;--navy-2:#232a3a;--code:#e8e0d0;--warn:#f4e0c4;--audit:#ead6cc;--note:#d7e6e2;--line:#cfc4b0;--rail:17.4rem}
+*{box-sizing:border-box}html{scroll-behavior:smooth}
+body{margin:0;background:var(--paper);color:var(--ink);font:16.5px/1.58 "Iowan Old Style","Palatino Linotype",Palatino,"Book Antiqua",Georgia,serif}
+.skip{position:absolute;left:-999px}.skip:focus{left:1rem;top:1rem;background:#fff;padding:.4rem;z-index:2}
+.shell{display:flex;min-height:100vh}
+.rail{width:var(--rail);flex:0 0 var(--rail);background:var(--navy);color:#d9d2c4;padding:1.35rem 1.05rem 2rem;position:sticky;top:0;height:100vh;overflow:auto}
+.rail .brand{color:#f3eee4;text-decoration:none;font:700 1.12rem/1.25 ui-sans-serif,system-ui,sans-serif;letter-spacing:.03em;display:block}
+.rail .brand span{color:var(--copper-2)}
+.rail .tag{font:12px/1.4 ui-sans-serif,system-ui,sans-serif;color:#9a9284;margin:.45rem 0 1.15rem}
+.rail ol{list-style:none;margin:0;padding:0}
+.rail a{display:block;color:#cfc6b6;text-decoration:none;padding:.36rem .5rem;border-left:3px solid transparent;font:13.5px/1.35 ui-sans-serif,system-ui,sans-serif}
+.rail a:hover{color:#fff;background:var(--navy-2)}
+.rail a.current{color:#fff;border-left-color:var(--copper-2);background:var(--navy-2)}
+.rail .num{color:var(--copper-2);margin-right:.35rem;font-variant-numeric:tabular-nums}
+main{flex:1;max-width:54rem;padding:2.1rem 2.3rem 4rem}
+h1,h2,h3,h4{font-family:ui-sans-serif,system-ui,"Segoe UI",sans-serif;letter-spacing:-.02em;line-height:1.25}
+h1{font-size:2.05rem;margin:0 0 .35rem;color:var(--navy)}
+h2{font-size:1.32rem;margin:2.1rem 0 .65rem;padding-top:.55rem;border-top:1px solid var(--line);color:var(--copper)}
+h3{font-size:1.06rem;margin:1.45rem 0 .45rem;color:var(--teal)}
+.lede{font-size:1.12rem;color:var(--mute)}
+.kicker{font:700 .7rem/1 ui-sans-serif,system-ui,sans-serif;letter-spacing:.16em;text-transform:uppercase;color:var(--copper);margin:0 0 .55rem}
+code,pre{font-family:ui-monospace,"SFMono-Regular",Menlo,Consolas,monospace;font-size:.86em}
+code{background:var(--paper-2);padding:.07em .32em;border-radius:3px}
+pre{background:var(--navy);color:var(--code);padding:1rem 1.1rem;overflow:auto;border-radius:4px;line-height:1.45}
+pre code{background:none;padding:0;color:inherit}
+.figure{background:var(--navy);border-radius:6px;padding:1rem 1rem .55rem;margin:1.15rem 0 1.5rem}
+.figure figcaption{color:#9a9284;font:12.5px/1.4 ui-sans-serif,system-ui,sans-serif;margin-top:.45rem}
+.callout{border-left:4px solid var(--teal-2);background:var(--note);padding:.75rem 1rem;margin:1.05rem 0}
+.callout.warn{border-color:var(--copper);background:var(--warn)}
+.callout.audit{border-color:#7a2e1a;background:var(--audit)}
+.callout strong{font-family:ui-sans-serif,system-ui,sans-serif}
+table{border-collapse:collapse;width:100%;font-size:.92rem;margin:1rem 0 1.35rem}
+th,td{border-bottom:1px solid var(--line);padding:.42rem .48rem;text-align:left;vertical-align:top}
+th{font:700 .72rem/1.3 ui-sans-serif,system-ui,sans-serif;text-transform:uppercase;letter-spacing:.06em;color:var(--mute)}
+.pager{display:flex;justify-content:space-between;gap:1rem;margin-top:2.4rem;padding-top:1rem;border-top:1px solid var(--line);font:14px/1.4 ui-sans-serif,system-ui,sans-serif}
+.pager a{color:var(--teal)}
+ul,ol{padding-left:1.2rem}li{margin:.26rem 0}
+a{color:var(--teal)}
+@media(max-width:860px){.shell{display:block}.rail{position:relative;height:auto;width:auto}}
+</style>
+</head>
+<body>
+<a class="skip" href="#main">Skip to content</a>
+<div class="shell">
+<aside class="rail" aria-label="Manual">
+  <a class="brand" href="index.html">Orbit <span>field manual</span></a>
+  <p class="tag">Architecture + audit<br>tree at <code>96b2714</code></p>
+  <ol>
+    <li><a class="current" href="index.html"><span class="num">01</span>Overview</a></li>
+    <li><a href="architecture.html"><span class="num">02</span>Architecture</a></li>
+    <li><a href="linux-tracing.html"><span class="num">03</span>Linux tracing</a></li>
+    <li><a href="instrumentation.html"><span class="num">04</span>Instrumentation</a></li>
+    <li><a href="client-ui.html"><span class="num">05</span>Client UI</a></li>
+    <li><a href="symbols-modules.html"><span class="num">06</span>Symbols &amp; modules</a></li>
+    <li><a href="kernel-assumptions.html"><span class="num">07</span>Kernel assumptions</a></li>
+    <li><a href="audit.html"><span class="num">08</span>Audit</a></li>
+    <li><a href="roadmap.html"><span class="num">09</span>Roadmap</a></li>
+  </ol>
+</aside>
+<main id="main">
+<p class="kicker">Orbit · Open Runtime Binary Instrumentation Tool</p>
+<h1>What Orbit is, and how to read this</h1>
+<p class="lede">Orbit is a native sampling + dynamic-instrumentation profiler. The interesting half of the product lives in a privileged collector (<code>OrbitService</code>) that talks to the kernel through <code>perf_event_open</code>. The Qt client is a remote viewer of that stream.</p>
+
+<div class="callout">
+  <strong>How to use these pages.</strong> They are a hosted manual, not a README. Each page names files and functions that exist in this tree. Open the path if you have the repo; you should not need the repo to understand the system. Relative links work as files or as a static site.
+</div>
+
+<h2>Product in one paragraph</h2>
+<p>The root <code>README.md</code> states the contract: no source change, no rebuild, no relaunch of the target. Sampling finds candidates; dynamic instrumentation records exact function entry/exit as hierarchical timers; scheduling, memory, AMD GPU driver events, Vulkan markers, and optional Python stacks sit on the same timeline. Serialization of a capture is a first-class file format (<code>src/CaptureFile/FORMAT.md</code>, signature <code>ORBT</code>).</p>
+<p>Focus has shifted to Linux. Windows local profiling is partial: ETW sampling and context switches exist; dynamic instrumentation does not. A Windows UI can still drive a Linux <code>OrbitService</code> over SSH. That split is real in the code, not just marketing — see <code>src/Service/OrbitGrpcServer.cpp</code>.</p>
+
+<h2>Map of the system</h2>
+<figure class="figure" aria-label="Process map">
+<svg viewBox="0 0 720 340" width="100%" height="auto" role="img" aria-labelledby="mapTitle mapDesc">
+  <title id="mapTitle">Orbit process map</title>
+  <desc id="mapDesc">Qt client talks gRPC to OrbitService. OrbitService owns LinuxCaptureService, which starts TracerImpl and optional user-space instrumentation. Producers connect on a Unix socket. The kernel supplies perf events.</desc>
+  <rect width="720" height="340" fill="#161b27"/>
+  <g fill="none" stroke="#c4622d" stroke-width="1.4">
+    <rect x="24" y="28" width="200" height="92" rx="4"/>
+    <rect x="260" y="28" width="220" height="92" rx="4"/>
+    <rect x="516" y="28" width="180" height="92" rx="4"/>
+    <rect x="24" y="168" width="200" height="92" rx="4"/>
+    <rect x="260" y="168" width="220" height="92" rx="4"/>
+    <rect x="516" y="168" width="180" height="92" rx="4"/>
+  </g>
+  <g fill="#f3eee4" font-family="ui-sans-serif,system-ui,sans-serif" font-size="13">
+    <text x="36" y="52" fill="#c4622d" font-size="11">CLIENT</text>
+    <text x="36" y="74">Orbit (Qt)</text>
+    <text x="36" y="94" fill="#9a9284" font-size="11">src/Orbit · OrbitQt · OrbitGl</text>
+    <text x="272" y="52" fill="#c4622d" font-size="11">SERVICE</text>
+    <text x="272" y="74">OrbitService :44765</text>
+    <text x="272" y="94" fill="#9a9284" font-size="11">src/Service · LinuxCaptureService</text>
+    <text x="528" y="52" fill="#c4622d" font-size="11">TARGET</text>
+    <text x="528" y="74">profiled process</text>
+    <text x="528" y="94" fill="#9a9284" font-size="11">optional liborbit.so / trampolines</text>
+    <text x="36" y="192" fill="#c4622d" font-size="11">PRODUCERS</text>
+    <text x="36" y="214">Unix socket</text>
+    <text x="36" y="234" fill="#9a9284" font-size="11">/tmp/orbit-producer-side-socket</text>
+    <text x="272" y="192" fill="#c4622d" font-size="11">KERNEL</text>
+    <text x="272" y="214">perf_event_open</text>
+    <text x="272" y="234" fill="#9a9284" font-size="11">uprobe PMU · tracepoints · mmap</text>
+    <text x="528" y="192" fill="#c4622d" font-size="11">OPTIONAL</text>
+    <text x="528" y="214">Vulkan layer</text>
+    <text x="528" y="234" fill="#9a9284" font-size="11">src/OrbitVulkanLayer</text>
+  </g>
+  <g stroke="#2d7a74" stroke-width="1.6" fill="none">
+    <path d="M224 74 H260"/>
+    <path d="M480 74 H516"/>
+    <path d="M370 120 V168"/>
+    <path d="M124 168 V120"/>
+    <path d="M606 120 V168"/>
+  </g>
+</svg>
+<figcaption>Three processes that matter: the Qt UI, <code>OrbitService</code>, and the target. Everything else is a producer attached to the service or a kernel fd owned by <code>TracerImpl</code>.</figcaption>
+</figure>
+
+<h2>How to read this manual</h2>
+<table>
+  <thead><tr><th>Page</th><th>What it answers</th></tr></thead>
+  <tbody>
+    <tr><td><a href="architecture.html">Architecture</a></td><td>Who talks to whom, capture start/stop, gRPC, SSH, producer socket, capture file.</td></tr>
+    <tr><td><a href="linux-tracing.html">Linux tracing</a></td><td><code>TracerImpl</code>: uprobes, ring buffers, per-CPU fds, visitors, start/stop.</td></tr>
+    <tr><td><a href="instrumentation.html">Instrumentation</a></td><td>Kernel uprobes vs ptrace trampolines vs the Orbit API vs py-spy.</td></tr>
+    <tr><td><a href="client-ui.html">Client UI</a></td><td>Session setup, capture view, tracks, Hook, options that actually exist.</td></tr>
+    <tr><td><a href="symbols-modules.html">Symbols &amp; modules</a></td><td>ELF/DWARF/PE/PDB, module mmap updates, Wine/PE traps.</td></tr>
+    <tr><td><a href="kernel-assumptions.html">Kernel assumptions</a></td><td>The implicit kernel/distro contract. This is the page to argue with.</td></tr>
+    <tr><td><a href="audit.html">Audit</a></td><td>Shortcomings, leftovers, test/CI gaps, footguns. Hunches labelled as such.</td></tr>
+    <tr><td><a href="roadmap.html">Roadmap</a></td><td>What to fix or add, ordered by leverage on the product as it exists.</td></tr>
+  </tbody>
+</table>
+
+<h2>What this review actually ran</h2>
+<p>This VM is <code>Linux 6.12.94+</code>, 4 CPUs, <code>perf_event_paranoid=2</code>, uid 1000. There is <strong>no</strong> uprobe PMU at <code>/sys/bus/event_source/devices/uprobe/type</code>, and no <code>uprobe_events</code> under tracefs or debugfs. Qt5 is not installed. A full <code>OrbitQt</code> / <code>LinuxTracing</code> build was <strong>not</strong> attempted. Integration tests and the opt-in uprobe bench from PR <a href="https://github.com/pierricgimmig/orbit/pull/10">#10</a> were not run. No timings in these pages were measured here.</p>
+<p>What <em>was</em> done: read the tree, including <code>src/LinuxTracing/TracerImpl.cpp</code>, <code>PerfEventOpen.cpp</code>, <code>LinuxCaptureServiceBase.cpp</code>, <code>UserSpaceInstrumentation</code>, UI/symbol paths, CI, and the open PR branch <code>cursor/fast-uprobe-stop-a3cf</code>. That branch is <strong>not</strong> merged into the tree these pages describe.</p>
+
+<div class="callout warn">
+  <strong>Do not treat PR #10 as current behavior.</strong> On <code>main</code>, stop still closes one uprobe PMU fd per CPU per function, sequentially. The tracefs-once design lives on that branch only. The kernel-assumptions and Linux-tracing pages cover both the historical cost and the proposed fix.
+</div>
+
+<h2>Source map (real directories)</h2>
+<table>
+  <thead><tr><th>Tree</th><th>Role</th></tr></thead>
+  <tbody>
+    <tr><td><code>src/Orbit</code>, <code>OrbitQt</code>, <code>OrbitGl</code></td><td>Client binary, Qt chrome, capture canvas + tracks.</td></tr>
+    <tr><td><code>src/Service</code></td><td><code>OrbitService</code> process; wires gRPC services.</td></tr>
+    <tr><td><code>src/LinuxCaptureService</code></td><td>Capture RPC, user-space vs uprobe split, memory watchdog.</td></tr>
+    <tr><td><code>src/LinuxTracing</code></td><td><code>TracerImpl</code>: <code>perf_event_open</code>, ring buffers, visitors.</td></tr>
+    <tr><td><code>src/UserSpaceInstrumentation</code></td><td>ptrace, trampolines, injected <code>liborbituserspaceinstrumentation.so</code>.</td></tr>
+    <tr><td><code>src/CaptureClient</code>, <code>ClientServices</code>, <code>SessionSetup</code></td><td>UI-side capture RPC, process list, SSH deploy.</td></tr>
+    <tr><td><code>src/Symbols</code>, <code>ObjectUtils</code>, <code>SymbolLoader</code></td><td>ELF/DWARF/PE/PDB load and cache.</td></tr>
+    <tr><td><code>src/ProducerSideService</code></td><td>In-process producers (API, Vulkan layer) on a Unix socket.</td></tr>
+    <tr><td><code>src/WindowsTracing</code>, <code>WindowsCaptureService</code></td><td>ETW path; no kernel-style dynamic hooks.</td></tr>
+    <tr><td><code>src/OrbitClientGgp*</code>, <code>OrbitCaptureGgp*</code></td><td>Stadia/GGP leftovers, still compiled.</td></tr>
+    <tr><td><code>third_party/py-spy-ffi</code></td><td>Rust FFI used by <code>PythonProfiler</code>.</td></tr>
+  </tbody>
+</table>
+
+<div class="callout audit">
+  <strong>Audit preview.</strong> The collector assumes a debugfs-mounted tracepoint id file, a cgroup-v1 cpuset layout, a live uprobe PMU, and root-or-equivalent for almost every interesting test. GitHub Actions excludes <code>IntegrationTest</code> binaries. Those facts are expanded on the <a href="kernel-assumptions.html">kernel</a> and <a href="audit.html">audit</a> pages — they are not hunches.
+</div>
+
+<nav class="pager">
+  <span></span>
+  <a href="architecture.html">Architecture →</a>
+</nav>
+</main>
+</div>
+</body>
+</html>

--- a/docs/manual/instrumentation.html
+++ b/docs/manual/instrumentation.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Orbit field manual — Instrumentation</title>
+<style>
+:root{--paper:#f3eee4;--paper-2:#e8e0d0;--ink:#1c1914;--mute:#5c564c;--copper:#9a3f1a;--copper-2:#c4622d;--teal:#1a4f4c;--teal-2:#2d7a74;--navy:#161b27;--navy-2:#232a3a;--code:#e8e0d0;--warn:#f4e0c4;--audit:#ead6cc;--note:#d7e6e2;--line:#cfc4b0;--rail:17.4rem}
+*{box-sizing:border-box}html{scroll-behavior:smooth}
+body{margin:0;background:var(--paper);color:var(--ink);font:16.5px/1.58 "Iowan Old Style","Palatino Linotype",Palatino,"Book Antiqua",Georgia,serif}
+.skip{position:absolute;left:-999px}.skip:focus{left:1rem;top:1rem;background:#fff;padding:.4rem;z-index:2}
+.shell{display:flex;min-height:100vh}
+.rail{width:var(--rail);flex:0 0 var(--rail);background:var(--navy);color:#d9d2c4;padding:1.35rem 1.05rem 2rem;position:sticky;top:0;height:100vh;overflow:auto}
+.rail .brand{color:#f3eee4;text-decoration:none;font:700 1.12rem/1.25 ui-sans-serif,system-ui,sans-serif;letter-spacing:.03em;display:block}
+.rail .brand span{color:var(--copper-2)}
+.rail .tag{font:12px/1.4 ui-sans-serif,system-ui,sans-serif;color:#9a9284;margin:.45rem 0 1.15rem}
+.rail ol{list-style:none;margin:0;padding:0}
+.rail a{display:block;color:#cfc6b6;text-decoration:none;padding:.36rem .5rem;border-left:3px solid transparent;font:13.5px/1.35 ui-sans-serif,system-ui,sans-serif}
+.rail a:hover{color:#fff;background:var(--navy-2)}
+.rail a.current{color:#fff;border-left-color:var(--copper-2);background:var(--navy-2)}
+.rail .num{color:var(--copper-2);margin-right:.35rem;font-variant-numeric:tabular-nums}
+main{flex:1;max-width:54rem;padding:2.1rem 2.3rem 4rem}
+h1,h2,h3,h4{font-family:ui-sans-serif,system-ui,"Segoe UI",sans-serif;letter-spacing:-.02em;line-height:1.25}
+h1{font-size:2.05rem;margin:0 0 .35rem;color:var(--navy)}
+h2{font-size:1.32rem;margin:2.1rem 0 .65rem;padding-top:.55rem;border-top:1px solid var(--line);color:var(--copper)}
+h3{font-size:1.06rem;margin:1.45rem 0 .45rem;color:var(--teal)}
+.lede{font-size:1.12rem;color:var(--mute)}
+.kicker{font:700 .7rem/1 ui-sans-serif,system-ui,sans-serif;letter-spacing:.16em;text-transform:uppercase;color:var(--copper);margin:0 0 .55rem}
+code,pre{font-family:ui-monospace,"SFMono-Regular",Menlo,Consolas,monospace;font-size:.86em}
+code{background:var(--paper-2);padding:.07em .32em;border-radius:3px}
+pre{background:var(--navy);color:var(--code);padding:1rem 1.1rem;overflow:auto;border-radius:4px;line-height:1.45}
+pre code{background:none;padding:0;color:inherit}
+.figure{background:var(--navy);border-radius:6px;padding:1rem 1rem .55rem;margin:1.15rem 0 1.5rem}
+.figure figcaption{color:#9a9284;font:12.5px/1.4 ui-sans-serif,system-ui,sans-serif;margin-top:.45rem}
+.callout{border-left:4px solid var(--teal-2);background:var(--note);padding:.75rem 1rem;margin:1.05rem 0}
+.callout.warn{border-color:var(--copper);background:var(--warn)}
+.callout.audit{border-color:#7a2e1a;background:var(--audit)}
+.callout strong{font-family:ui-sans-serif,system-ui,sans-serif}
+table{border-collapse:collapse;width:100%;font-size:.92rem;margin:1rem 0 1.35rem}
+th,td{border-bottom:1px solid var(--line);padding:.42rem .48rem;text-align:left;vertical-align:top}
+th{font:700 .72rem/1.3 ui-sans-serif,system-ui,sans-serif;text-transform:uppercase;letter-spacing:.06em;color:var(--mute)}
+.pager{display:flex;justify-content:space-between;gap:1rem;margin-top:2.4rem;padding-top:1rem;border-top:1px solid var(--line);font:14px/1.4 ui-sans-serif,system-ui,sans-serif}
+.pager a{color:var(--teal)}
+ul,ol{padding-left:1.2rem}li{margin:.26rem 0}
+a{color:var(--teal)}
+@media(max-width:860px){.shell{display:block}.rail{position:relative;height:auto;width:auto}}
+</style>
+</head>
+<body>
+<a class="skip" href="#main">Skip to content</a>
+<div class="shell">
+<aside class="rail" aria-label="Manual">
+  <a class="brand" href="index.html">Orbit <span>field manual</span></a>
+  <p class="tag">Architecture + audit<br>tree at <code>96b2714</code></p>
+  <ol>
+    <li><a href="index.html"><span class="num">01</span>Overview</a></li>
+    <li><a href="architecture.html"><span class="num">02</span>Architecture</a></li>
+    <li><a href="linux-tracing.html"><span class="num">03</span>Linux tracing</a></li>
+    <li><a class="current" href="instrumentation.html"><span class="num">04</span>Instrumentation</a></li>
+    <li><a href="client-ui.html"><span class="num">05</span>Client UI</a></li>
+    <li><a href="symbols-modules.html"><span class="num">06</span>Symbols &amp; modules</a></li>
+    <li><a href="kernel-assumptions.html"><span class="num">07</span>Kernel assumptions</a></li>
+    <li><a href="audit.html"><span class="num">08</span>Audit</a></li>
+    <li><a href="roadmap.html"><span class="num">09</span>Roadmap</a></li>
+  </ol>
+</aside>
+<main id="main">
+<p class="kicker">Uprobes · trampolines · API · Wine · Python</p>
+<h1>Instrumentation</h1>
+<p class="lede">“Hook” in the UI is not one mechanism. The service picks a dynamic method, then falls back. Manual markers and Python stacks are separate producers that only look like timers in the client.</p>
+
+<h2>From Hook to a probe</h2>
+<p>Right-click <strong>Hook</strong> is <code>kMenuActionSelect</code> in <code>src/DataViews/include/DataViews/DataView.h</code>. <code>FunctionsDataView</code> marks the row with <code>H</code>. That calls <code>OrbitApp::SelectFunction</code> → <code>DataManager::SelectFunction</code>. Nothing is planted in the target until capture starts.</p>
+<p><code>CaptureClient</code> copies selected functions into <code>CaptureOptions.instrumented_functions</code> (file path, build id, file offset, virtual address, size, name, record-args / record-retval). It requires the method to be <code>kKernelUprobes</code> or <code>kUserSpaceInstrumentation</code>.</p>
+<p>The UI default is <strong>user-space instrumentation</strong> (<code>CaptureOptionsDialog::kDynamicInstrumentationMethodDefaultValue</code>). GGP leftover clients still force <code>kKernelUprobes</code> (<code>src/OrbitClientGgp/ClientGgp.cpp</code>).</p>
+
+<h2>Two dynamic methods</h2>
+<figure class="figure" aria-label="Instrumentation methods">
+<svg viewBox="0 0 720 220" width="100%" height="auto" role="img">
+  <title>Kernel uprobes versus user-space trampolines</title>
+  <rect width="720" height="220" fill="#161b27"/>
+  <g fill="none" stroke="#c4622d" stroke-width="1.3">
+    <rect x="20" y="36" width="330" height="160" rx="4"/>
+    <rect x="370" y="36" width="330" height="160" rx="4"/>
+  </g>
+  <g fill="#f3eee4" font-family="ui-sans-serif,system-ui,sans-serif" font-size="12">
+    <text x="36" y="60" fill="#c4622d">kKernelUprobes</text>
+    <text x="36" y="84">perf_event_open uprobe PMU</text>
+    <text x="36" y="104">int3 / trampoline in kernel</text>
+    <text x="36" y="124">2 fds × CPUs × function</text>
+    <text x="36" y="144">no ptrace, works if PMU exists</text>
+    <text x="36" y="164">UI calls this “slower”</text>
+    <text x="386" y="60" fill="#c4622d">kUserSpaceInstrumentation</text>
+    <text x="386" y="84">ptrace attach, allocate, inject .so</text>
+    <text x="386" y="104">overwrite prologue → trampoline</text>
+    <text x="386" y="124">FunctionEntry/Exit via producer</text>
+    <text x="386" y="144">hijacked back into TracerImpl</text>
+    <text x="386" y="164">x86_64 only (ARM64 is a stub)</text>
+  </g>
+</svg>
+<figcaption>Both paths produce <code>FunctionCall</code> events. Failures of the user-space path leave those functions in <code>linux_tracing_capture_options</code> so uprobes still try.</figcaption>
+</figure>
+
+<h3>Kernel uprobes</h3>
+<p>Covered on the <a href="linux-tracing.html">Linux tracing</a> page. Requirements: <code>CONFIG_UPROBE_EVENTS</code>, the uprobe PMU in sysfs, privileges that satisfy <code>perf_event_paranoid</code>, and a file-backed mapping of the function (Wine PEs often fail this — <code>FindFunctionsThatUprobesCannotInstrumentWithMessages</code>).</p>
+<p>Uprobes cannot instrument a function that is not (yet) mapped. The warning text promises automatic instrumentation if the module loads later; that depends on mmap events + the existing fd already covering that file offset for the inode. Newly loaded modules with <em>new</em> paths need new opens; the current <code>Startup</code> path does not re-run <code>OpenUserSpaceProbes</code> mid-capture.</p>
+
+<h3>User-space instrumentation</h3>
+<p><code>InstrumentationManager::InstrumentProcess</code> (<code>src/UserSpaceInstrumentation/InstrumentProcess.cpp</code>):</p>
+<ol>
+  <li>Locate <code>liborbituserspaceinstrumentation.so</code> next to <code>OrbitService</code> or in <code>../lib</code>.</li>
+  <li>If not already injected, <code>InjectLibraryInTracee</code> (ptrace, allocate, <code>dlopen</code> in the target).</li>
+  <li>Clone a helper thread in the tracee to run <code>InitializeInstrumentation</code> (machine code in <code>MachineCodeForCloneCall</code> — syscall numbers are x86_64).</li>
+  <li>For each function: skip the libc blocklist, disassemble with Capstone, emit a trampoline, overwrite the prologue with a jump.</li>
+  <li>Return trampoline ranges + injected path so LinuxTracing can hide them from unwind.</li>
+</ol>
+<p><code>UninstrumentProcess</code> restores prologues only. The library and trampoline mappings stay in the target for the life of the process / manager.</p>
+<p>Blocklisted names (<code>IsBlocklisted</code>) include malloc/free internals, <code>__GI_memcpy</code> (libc jumps into +0x3), pthread cancel helpers, etc. Those fall back to uprobes if the method is user-space and they were still in the options — actually they are skipped during InstrumentProcess and appear in <code>function_ids_to_error_messages</code>, then remain in the filtered-out set only if they <em>succeeded</em>. Failed ids stay in <code>linux_tracing_capture_options</code> and uprobes try them. That is the “slower kernel (uprobes)” message in <code>OrbitApp::OnErrorEnablingUserSpaceInstrumentationEvent</code> / <code>OnWarningInstrumentingWithUserSpaceInstrumentationEvent</code>.</p>
+<p>Strict seccomp: <code>AnyThreadIsInStrictSeccompMode</code> can refuse the attach. Hotpatchability is a field on <code>InstrumentedFunction</code> (<code>is_hotpatchable</code>) for the disassembler’s benefit.</p>
+
+<div class="callout warn">
+  <strong>ARM64.</strong> <code>src/UserSpaceInstrumentation/CMakeLists.txt</code> builds <code>StubArm64.cpp</code> that returns “not supported”. Kernel uprobes <em>do</em> have ARM64 register masks in <code>PerfEventOpen.h</code>. <code>docs/building_arm64.md</code> conflates the two and says “uprobes-based function hooking is not supported on ARM64”. That sentence is wrong: the disabled piece is the trampoline JIT, not the uprobe PMU.
+</div>
+
+<h2>Manual instrumentation (Orbit API)</h2>
+<p>Headers in <code>src/ApiInterface/Orbit.h</code>. User code instantiates the table with <code>ORBIT_API_INSTANTIATE</code>. <code>CaptureClient::FindApiFunctions</code> looks up versioned <code>OrbitApiGetFunctionTableAddress*</code> symbols in loaded modules. <code>EnableApiInTracee</code> writes function pointers into the target so scopes start emitting. Events arrive through the producer-side socket (<code>src/Api/LockFreeApiEventProducer.h</code>) as API scope / track / string events, not as uprobes.</p>
+<p>Frame tracks for manual scopes are still a TODO in <code>FrameTrack.cpp</code> (<code>b/169554463</code>).</p>
+
+<h2>Wine / Proton</h2>
+<p>Wine’s <code>__wine_syscall_dispatcher</code> switches to a different stack. DWARF unwind dies after that frame. <code>OrbitApp</code> implements <code>WineSyscallHandlingMethod</code>:</p>
+<ul>
+  <li><code>kNoSpecialHandling</code> — do nothing (hidden in some UI builds)</li>
+  <li><code>kStopUnwinding</code> — default; put the dispatcher in <code>functions_to_stop_unwinding_at</code></li>
+  <li><code>kRecordUserStack</code> — also add it to <code>functions_to_record_additional_stack_on</code> so a full stack is snapped before the switch</li>
+</ul>
+<p>PE modules mapped anonymously (Wine’s typical <code>.text</code> dance) cannot be uprobe targets; the warning string says so explicitly in <code>LinuxTracingUtils.cpp</code>.</p>
+
+<h2>Python</h2>
+<p>Not dynamic instrumentation. <code>PythonSamplingThread</code> samples interpreter stacks via py-spy FFI and synthesizes callstacks / address infos. Auto-enable if the exe name looks like Python — a process named <code>my-python-wrapper</code> matches; an embedded interpreter in <code>blender</code> does not. <code>python_include_native</code> turns on <code>pyspy_new_with_native</code>.</p>
+
+<h2>What “dynamic function calls” means in the UI</h2>
+<p>A <code>FunctionCall</code> is a closed interval: pid, tid, function id, duration, end timestamp, depth, optional retval, optional six argument registers. Thread tracks draw them as nested timers. Sampling still runs independently; <code>UprobesUnwindingVisitor</code> must patch samples that fall inside an open dynamic frame so the callstack is not a lie.</p>
+
+<nav class="pager">
+  <a href="linux-tracing.html">← Linux tracing</a>
+  <a href="client-ui.html">Client UI →</a>
+</nav>
+</main>
+</div>
+</body>
+</html>

--- a/docs/manual/kernel-assumptions.html
+++ b/docs/manual/kernel-assumptions.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Orbit field manual — Kernel assumptions</title>
+<style>
+:root{--paper:#f3eee4;--paper-2:#e8e0d0;--ink:#1c1914;--mute:#5c564c;--copper:#9a3f1a;--copper-2:#c4622d;--teal:#1a4f4c;--teal-2:#2d7a74;--navy:#161b27;--navy-2:#232a3a;--code:#e8e0d0;--warn:#f4e0c4;--audit:#ead6cc;--note:#d7e6e2;--line:#cfc4b0;--rail:17.4rem}
+*{box-sizing:border-box}html{scroll-behavior:smooth}
+body{margin:0;background:var(--paper);color:var(--ink);font:16.5px/1.58 "Iowan Old Style","Palatino Linotype",Palatino,"Book Antiqua",Georgia,serif}
+.skip{position:absolute;left:-999px}.skip:focus{left:1rem;top:1rem;background:#fff;padding:.4rem;z-index:2}
+.shell{display:flex;min-height:100vh}
+.rail{width:var(--rail);flex:0 0 var(--rail);background:var(--navy);color:#d9d2c4;padding:1.35rem 1.05rem 2rem;position:sticky;top:0;height:100vh;overflow:auto}
+.rail .brand{color:#f3eee4;text-decoration:none;font:700 1.12rem/1.25 ui-sans-serif,system-ui,sans-serif;letter-spacing:.03em;display:block}
+.rail .brand span{color:var(--copper-2)}
+.rail .tag{font:12px/1.4 ui-sans-serif,system-ui,sans-serif;color:#9a9284;margin:.45rem 0 1.15rem}
+.rail ol{list-style:none;margin:0;padding:0}
+.rail a{display:block;color:#cfc6b6;text-decoration:none;padding:.36rem .5rem;border-left:3px solid transparent;font:13.5px/1.35 ui-sans-serif,system-ui,sans-serif}
+.rail a:hover{color:#fff;background:var(--navy-2)}
+.rail a.current{color:#fff;border-left-color:var(--copper-2);background:var(--navy-2)}
+.rail .num{color:var(--copper-2);margin-right:.35rem;font-variant-numeric:tabular-nums}
+main{flex:1;max-width:54rem;padding:2.1rem 2.3rem 4rem}
+h1,h2,h3,h4{font-family:ui-sans-serif,system-ui,"Segoe UI",sans-serif;letter-spacing:-.02em;line-height:1.25}
+h1{font-size:2.05rem;margin:0 0 .35rem;color:var(--navy)}
+h2{font-size:1.32rem;margin:2.1rem 0 .65rem;padding-top:.55rem;border-top:1px solid var(--line);color:var(--copper)}
+h3{font-size:1.06rem;margin:1.45rem 0 .45rem;color:var(--teal)}
+.lede{font-size:1.12rem;color:var(--mute)}
+.kicker{font:700 .7rem/1 ui-sans-serif,system-ui,sans-serif;letter-spacing:.16em;text-transform:uppercase;color:var(--copper);margin:0 0 .55rem}
+code,pre{font-family:ui-monospace,"SFMono-Regular",Menlo,Consolas,monospace;font-size:.86em}
+code{background:var(--paper-2);padding:.07em .32em;border-radius:3px}
+pre{background:var(--navy);color:var(--code);padding:1rem 1.1rem;overflow:auto;border-radius:4px;line-height:1.45}
+pre code{background:none;padding:0;color:inherit}
+.figure{background:var(--navy);border-radius:6px;padding:1rem 1rem .55rem;margin:1.15rem 0 1.5rem}
+.figure figcaption{color:#9a9284;font:12.5px/1.4 ui-sans-serif,system-ui,sans-serif;margin-top:.45rem}
+.callout{border-left:4px solid var(--teal-2);background:var(--note);padding:.75rem 1rem;margin:1.05rem 0}
+.callout.warn{border-color:var(--copper);background:var(--warn)}
+.callout.audit{border-color:#7a2e1a;background:var(--audit)}
+.callout strong{font-family:ui-sans-serif,system-ui,sans-serif}
+table{border-collapse:collapse;width:100%;font-size:.92rem;margin:1rem 0 1.35rem}
+th,td{border-bottom:1px solid var(--line);padding:.42rem .48rem;text-align:left;vertical-align:top}
+th{font:700 .72rem/1.3 ui-sans-serif,system-ui,sans-serif;text-transform:uppercase;letter-spacing:.06em;color:var(--mute)}
+.pager{display:flex;justify-content:space-between;gap:1rem;margin-top:2.4rem;padding-top:1rem;border-top:1px solid var(--line);font:14px/1.4 ui-sans-serif,system-ui,sans-serif}
+.pager a{color:var(--teal)}
+ul,ol{padding-left:1.2rem}li{margin:.26rem 0}
+a{color:var(--teal)}
+@media(max-width:860px){.shell{display:block}.rail{position:relative;height:auto;width:auto}}
+</style>
+</head>
+<body>
+<a class="skip" href="#main">Skip to content</a>
+<div class="shell">
+<aside class="rail" aria-label="Manual">
+  <a class="brand" href="index.html">Orbit <span>field manual</span></a>
+  <p class="tag">Architecture + audit<br>tree at <code>96b2714</code></p>
+  <ol>
+    <li><a href="index.html"><span class="num">01</span>Overview</a></li>
+    <li><a href="architecture.html"><span class="num">02</span>Architecture</a></li>
+    <li><a href="linux-tracing.html"><span class="num">03</span>Linux tracing</a></li>
+    <li><a href="instrumentation.html"><span class="num">04</span>Instrumentation</a></li>
+    <li><a href="client-ui.html"><span class="num">05</span>Client UI</a></li>
+    <li><a href="symbols-modules.html"><span class="num">06</span>Symbols &amp; modules</a></li>
+    <li><a class="current" href="kernel-assumptions.html"><span class="num">07</span>Kernel assumptions</a></li>
+    <li><a href="audit.html"><span class="num">08</span>Audit</a></li>
+    <li><a href="roadmap.html"><span class="num">09</span>Roadmap</a></li>
+  </ol>
+</aside>
+<main id="main">
+<p class="kicker">Uprobe PMU · tracefs · event_mutex · cgroup · paranoid</p>
+<h1>Kernel and distro assumptions</h1>
+<p class="lede">Orbit does not probe a kernel version and branch. It assumes a Google/Stadia-era Linux userspace and a kernel that still looks like that. Several of those assumptions are now false on stock Ubuntu, Raspberry Pi OS, and this review VM.</p>
+
+<div class="callout warn">
+  <strong>This page mixes two kinds of fact.</strong> (1) What the <em>Orbit tree</em> does — verified by reading <code>main</code>. (2) What the <em>kernel</em> does on close of a per-CPU uprobe PMU fd — taken from PR #10’s kernel reading and the usual <code>perf_uprobe_destroy</code> path. That kernel path was not re-read from a kernel tree in this review, and no timings were taken here.
+</div>
+
+<h2>There is no kernel version gate</h2>
+<p><code>OrbitService</code> logs <code>uname -a</code> and stops there. The only in-tree comment that names a kernel version is <code>KernelTracepoints.h</code>: <code>sched_wakeup</code> dropped the <code>success</code> field in <strong>v5.14</strong> (commit <code>58b9987de86c</code>). Orbit does not read the tail of that struct, so both layouts work. Nothing else checks <code>KERNEL_VERSION</code>.</p>
+
+<h2>Uprobe PMU must exist</h2>
+<p><code>uprobe_type()</code> in <code>PerfEventOpen.cpp</code> does:</p>
+<pre><code>static uint32_t uprobe_type =
+    read_uint32_from_file("/sys/bus/event_source/devices/uprobe/type");</code></pre>
+<p>That requires <code>CONFIG_UPROBE_EVENTS</code> (and a kernel that exports the uprobe PMU). <code>read_uint32_from_file</code> calls <code>ReadFileToString(...).value()</code> then <code>std::stoul</code>. If the file is missing, this is an exception on first uprobe open — not a structured <code>ErrorsWithPerfEventOpenEvent</code>. This review VM has no such file.</p>
+<p>Uretprobe is bit 0 of <code>perf_event_attr.config</code> on that PMU. That ABI has been stable for a long time; Orbit never negotiates it.</p>
+
+<h2>Privileges: root and perf_event_paranoid</h2>
+<p>CPU-wide events (<code>pid=-1</code>) need either root or <code>perf_event_paranoid ≤ 0</code> (sometimes −1 depending on the event). Integration tests encode that:</p>
+<ul>
+  <li>Most tests: <code>CheckIsRunningAsRoot()</code> or skip.</li>
+  <li>Sampling-only tests: <code>CheckIsPerfEventParanoidAtMost(0)</code>.</li>
+</ul>
+<p>If opens fail, the user-visible hint is only “did you forget to run as root?”. There is no check of the sysctl before capture, and no attempt to drop to a smaller CPU set or switch to per-thread events.</p>
+<p><code>docs/building_arm64.md</code> suggests <code>sysctl kernel.perf_event_paranoid=-1</code> as an alternative to root. That is a machine-wide security change; the service still opens CPU-wide mmap/task/sched fds.</p>
+
+<h2>Tracefs vs debugfs</h2>
+<p><code>GetTracepointId</code> reads <strong>only</strong>:</p>
+<pre><code>/sys/kernel/debug/tracing/events/&lt;cat&gt;/&lt;name&gt;/id</code></pre>
+<p>It never tries <code>/sys/kernel/tracing/...</code> (tracefs, the path distributions have used as the primary mount for years). If debugfs is unmounted or not permitted, <em>every</em> tracepoint open fails: sched, task names, GPU, user-selected tracepoints. Sampling and uprobes (PMU path) do not use this helper; they can still work.</p>
+<p><code>KernelTracepoints.h</code> comments also cite the debugfs format files. Packed structs include “reserved” bytes “not documented in the format file” — another layout assumption.</p>
+
+<div class="callout audit">
+  <strong>This VM.</strong> <code>uname</code> reported <code>Linux 6.12.94+</code>. No <code>/sys/kernel/debug/tracing/events</code>, no <code>/sys/kernel/tracing/events</code> visible to uid 1000, no <code>uprobe_events</code>. A default <code>OrbitService</code> started here would fail the interesting opens and emit <code>ErrorsWithPerfEventOpenEvent</code> — if it got past <code>uprobe_type()</code> without throwing.
+</div>
+
+<h2>cgroup v1 cpuset</h2>
+<p><code>GetCpusetCpus</code> reads <code>/proc/&lt;pid&gt;/cgroup</code>, looks for a line containing <code>cpuset:</code> or <code>cpuset,</code>, then reads:</p>
+<pre><code>/sys/fs/cgroup/cpuset&lt;path&gt;/cpuset.cpus</code></pre>
+<p>That is <strong>cgroup v1</strong>. On cgroup v2 the file is elsewhere (<code>/sys/fs/cgroup/.../cpuset.cpus</code> without the <code>cpuset</code> controller directory, and the cgroup line format is different). The function returns empty, <code>Startup</code> logs “Could not read cpuset” and uses every CPU from <code>hardware_concurrency()</code>. That is safe (more fds, not fewer) but it is a Stadia-shaped leftover: comments mention <code>/game</code>.</p>
+<p><code>GetNumCores</code> prefers <code>std::thread::hardware_concurrency()</code>, then shells out to <code>nproc</code>. Offline CPUs and container quotas can disagree with the perf CPU index space (0..n-1).</p>
+
+<h2>Per-CPU PMU fds and event_mutex</h2>
+<p>On <code>main</code>, each instrumented function does <code>create_local_trace_uprobe</code> once per CPU (uprobe) and once per CPU (uretprobe). Closing a fd tears down that local probe.</p>
+<p>PR #10’s kernel note (not re-verified against a kernel source checkout in this review): <code>perf_uprobe_destroy</code> takes the global <code>event_mutex</code> for the <em>entire</em> close:</p>
+<ol>
+  <li><code>uprobe_apply(false)</code></li>
+  <li><code>uprobe_unregister_nosync</code> — VMA walk, <code>dup_mmap_sem</code> + <code>register_rwsem</code></li>
+  <li><code>uprobe_unregister_sync()</code> — RCU tasks-trace and uretprobes SRCU</li>
+  <li><code>tracepoint_synchronize_unregister</code></li>
+</ol>
+<figure class="figure" aria-label="close under event_mutex">
+<svg viewBox="0 0 720 200" width="100%" height="auto" role="img">
+  <title>Serialized close of per-CPU uprobe fds</title>
+  <rect width="720" height="200" fill="#161b27"/>
+  <g fill="#f3eee4" font-family="ui-sans-serif,system-ui,sans-serif" font-size="12">
+    <text x="24" y="32" fill="#c4622d">N parallel close() threads</text>
+    <text x="24" y="70">close fd0 ──► event_mutex ──► VMA walk + 2–3 RCU GPs ──► unlock</text>
+    <text x="24" y="100">close fd1 ──► queued on event_mutex ──────────────────────────► same</text>
+    <text x="24" y="130">close fd2 ──► queued ─────────────────────────────────────────► same</text>
+    <text x="24" y="168" fill="#9a9284">Wall time ≈ O(F × NCPU × 2 × (VMA walk + grace periods)). ParallelFor does not shrink this.</text>
+  </g>
+</svg>
+<figcaption>Historical cost of the current fd model. Newer kernels have grown batch-unregister helpers; Orbit on <code>main</code> does not call them.</figcaption>
+</figure>
+<p>Newer kernels expose more efficient unregister (batch / nosync variants used by perf and systemd-style tools). Orbit never calls those APIs. The production-quality fix explored in PR #10 is orthogonal and older-kernel-friendly: register each probe <strong>once</strong> via <code>uprobe_events</code>, open per-CPU fds as <code>PERF_TYPE_TRACEPOINT</code> consumers of that one registration. Sample fds stay <code>2×F×NCPU</code>; expensive destroys become <code>2×F</code>.</p>
+<p><code>pid=target, cpu=-1</code> was measured on that branch as an fd-count experiment and rejected for production (tid semantics, inherit, mmap). The bench is <code>LinuxTracingIntegrationTest.UprobeAttachDetachBench</code>, off unless <code>ORBIT_UPROBE_BENCH=1</code>. <strong>Not run here.</strong> Do not invent speedup numbers.</p>
+
+<h2>Other kernel / ABI assumptions</h2>
+<table>
+  <thead><tr><th>Assumption</th><th>Where</th><th>If false</th></tr></thead>
+  <tbody>
+    <tr><td>Clock <code>orbit_base::kOrbitCaptureClock</code> is valid in <code>perf_event_attr.clockid</code></td><td><code>generic_event_attr</code></td><td>open fails or timestamps disagree with <code>CaptureTimestampNs</code></td></tr>
+    <tr><td>User stack dump ≤ 65000</td><td><code>kMaxStackSampleUserSize</code></td><td>kernel rejects the attr</td></tr>
+    <tr><td><code>perf_event_max_stack</code> sysctl readable</td><td><code>max_stack()</code></td><td>same <code>.value()</code> throw as uprobe type</td></tr>
+    <tr><td>AMD tracepoints present</td><td><code>OpenGpuTracepoints</code></td><td>GPU silently disabled</td></tr>
+    <tr><td>x86_64 or aarch64 register ABI</td><td><code>PerfEventOpen.h</code></td><td>compile error (<code>#error</code>)</td></tr>
+    <tr><td>ptrace + <code>process_vm_readv</code> + userfault-free writes</td><td>UserSpaceInstrumentation</td><td>Yama, seccomp, or container: fallback to uprobes or hard error</td></tr>
+    <tr><td>Minidumps under <code>/usr/local/cloudcast/core</code></td><td><code>GetTargetProcessStateAfterCapture</code></td><td>crash detection does nothing</td></tr>
+  </tbody>
+</table>
+
+<h2>Raspberry Pi / ARM64</h2>
+<p>Cross-compile path is real (<code>docs/building_arm64.md</code>, <code>build_arm_service.sh</code>). Perf register masks exist for ARM64. User-space trampolines do not. GPU AMD tracepoints will not exist. Uprobe PMU availability depends on the Pi kernel config — not guaranteed, not checked.</p>
+
+<nav class="pager">
+  <a href="symbols-modules.html">← Symbols &amp; modules</a>
+  <a href="audit.html">Audit →</a>
+</nav>
+</main>
+</div>
+</body>
+</html>

--- a/docs/manual/linux-tracing.html
+++ b/docs/manual/linux-tracing.html
@@ -1,0 +1,173 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Orbit field manual — Linux tracing</title>
+<style>
+:root{--paper:#f3eee4;--paper-2:#e8e0d0;--ink:#1c1914;--mute:#5c564c;--copper:#9a3f1a;--copper-2:#c4622d;--teal:#1a4f4c;--teal-2:#2d7a74;--navy:#161b27;--navy-2:#232a3a;--code:#e8e0d0;--warn:#f4e0c4;--audit:#ead6cc;--note:#d7e6e2;--line:#cfc4b0;--rail:17.4rem}
+*{box-sizing:border-box}html{scroll-behavior:smooth}
+body{margin:0;background:var(--paper);color:var(--ink);font:16.5px/1.58 "Iowan Old Style","Palatino Linotype",Palatino,"Book Antiqua",Georgia,serif}
+.skip{position:absolute;left:-999px}.skip:focus{left:1rem;top:1rem;background:#fff;padding:.4rem;z-index:2}
+.shell{display:flex;min-height:100vh}
+.rail{width:var(--rail);flex:0 0 var(--rail);background:var(--navy);color:#d9d2c4;padding:1.35rem 1.05rem 2rem;position:sticky;top:0;height:100vh;overflow:auto}
+.rail .brand{color:#f3eee4;text-decoration:none;font:700 1.12rem/1.25 ui-sans-serif,system-ui,sans-serif;letter-spacing:.03em;display:block}
+.rail .brand span{color:var(--copper-2)}
+.rail .tag{font:12px/1.4 ui-sans-serif,system-ui,sans-serif;color:#9a9284;margin:.45rem 0 1.15rem}
+.rail ol{list-style:none;margin:0;padding:0}
+.rail a{display:block;color:#cfc6b6;text-decoration:none;padding:.36rem .5rem;border-left:3px solid transparent;font:13.5px/1.35 ui-sans-serif,system-ui,sans-serif}
+.rail a:hover{color:#fff;background:var(--navy-2)}
+.rail a.current{color:#fff;border-left-color:var(--copper-2);background:var(--navy-2)}
+.rail .num{color:var(--copper-2);margin-right:.35rem;font-variant-numeric:tabular-nums}
+main{flex:1;max-width:54rem;padding:2.1rem 2.3rem 4rem}
+h1,h2,h3,h4{font-family:ui-sans-serif,system-ui,"Segoe UI",sans-serif;letter-spacing:-.02em;line-height:1.25}
+h1{font-size:2.05rem;margin:0 0 .35rem;color:var(--navy)}
+h2{font-size:1.32rem;margin:2.1rem 0 .65rem;padding-top:.55rem;border-top:1px solid var(--line);color:var(--copper)}
+h3{font-size:1.06rem;margin:1.45rem 0 .45rem;color:var(--teal)}
+.lede{font-size:1.12rem;color:var(--mute)}
+.kicker{font:700 .7rem/1 ui-sans-serif,system-ui,sans-serif;letter-spacing:.16em;text-transform:uppercase;color:var(--copper);margin:0 0 .55rem}
+code,pre{font-family:ui-monospace,"SFMono-Regular",Menlo,Consolas,monospace;font-size:.86em}
+code{background:var(--paper-2);padding:.07em .32em;border-radius:3px}
+pre{background:var(--navy);color:var(--code);padding:1rem 1.1rem;overflow:auto;border-radius:4px;line-height:1.45}
+pre code{background:none;padding:0;color:inherit}
+.figure{background:var(--navy);border-radius:6px;padding:1rem 1rem .55rem;margin:1.15rem 0 1.5rem}
+.figure figcaption{color:#9a9284;font:12.5px/1.4 ui-sans-serif,system-ui,sans-serif;margin-top:.45rem}
+.callout{border-left:4px solid var(--teal-2);background:var(--note);padding:.75rem 1rem;margin:1.05rem 0}
+.callout.warn{border-color:var(--copper);background:var(--warn)}
+.callout.audit{border-color:#7a2e1a;background:var(--audit)}
+.callout strong{font-family:ui-sans-serif,system-ui,sans-serif}
+table{border-collapse:collapse;width:100%;font-size:.92rem;margin:1rem 0 1.35rem}
+th,td{border-bottom:1px solid var(--line);padding:.42rem .48rem;text-align:left;vertical-align:top}
+th{font:700 .72rem/1.3 ui-sans-serif,system-ui,sans-serif;text-transform:uppercase;letter-spacing:.06em;color:var(--mute)}
+.pager{display:flex;justify-content:space-between;gap:1rem;margin-top:2.4rem;padding-top:1rem;border-top:1px solid var(--line);font:14px/1.4 ui-sans-serif,system-ui,sans-serif}
+.pager a{color:var(--teal)}
+ul,ol{padding-left:1.2rem}li{margin:.26rem 0}
+a{color:var(--teal)}
+@media(max-width:860px){.shell{display:block}.rail{position:relative;height:auto;width:auto}}
+</style>
+</head>
+<body>
+<a class="skip" href="#main">Skip to content</a>
+<div class="shell">
+<aside class="rail" aria-label="Manual">
+  <a class="brand" href="index.html">Orbit <span>field manual</span></a>
+  <p class="tag">Architecture + audit<br>tree at <code>96b2714</code></p>
+  <ol>
+    <li><a href="index.html"><span class="num">01</span>Overview</a></li>
+    <li><a href="architecture.html"><span class="num">02</span>Architecture</a></li>
+    <li><a class="current" href="linux-tracing.html"><span class="num">03</span>Linux tracing</a></li>
+    <li><a href="instrumentation.html"><span class="num">04</span>Instrumentation</a></li>
+    <li><a href="client-ui.html"><span class="num">05</span>Client UI</a></li>
+    <li><a href="symbols-modules.html"><span class="num">06</span>Symbols &amp; modules</a></li>
+    <li><a href="kernel-assumptions.html"><span class="num">07</span>Kernel assumptions</a></li>
+    <li><a href="audit.html"><span class="num">08</span>Audit</a></li>
+    <li><a href="roadmap.html"><span class="num">09</span>Roadmap</a></li>
+  </ol>
+</aside>
+<main id="main">
+<p class="kicker">TracerImpl · perf_event_open · ring buffers</p>
+<h1>Linux tracing</h1>
+<p class="lede">All kernel-side capture on Linux is <code>orbit_linux_tracing::TracerImpl</code>. It is one thread that opens a swarm of per-CPU file descriptors, mmaps ring buffers, polls them round-robin, and a second thread that drains a deferred queue in timestamp order.</p>
+
+<h2>Lifetime</h2>
+<p><code>Tracer::Create</code> (<code>src/LinuxTracing/Tracer.cpp</code>) constructs a <code>TracerImpl</code>. <code>Start</code> spawns <code>run_thread_</code> on <code>TracerImpl::Run</code>. <code>Stop</code> sets <code>stop_run_thread_</code> and joins. There is no pause. <code>TracingHandler</code> does not reset the tracer after <code>Stop</code>; the comment in <code>TracingHandler.cpp</code> says the object cannot be reused.</p>
+<p><code>Run</code> calls <code>Startup</code>, starts <code>ProcessDeferredEvents</code> on a side thread, then loops: sleep 5&nbsp;ms if the last pass saw nothing, otherwise read up to <code>kRoundRobinPollingBatchSize</code> (5) records from each <code>PerfEventRingBuffer</code>. On exit it joins the deferred thread, <code>ProcessAllEvents</code>, then <code>Shutdown</code>.</p>
+
+<h2>What Startup opens</h2>
+<p><code>TracerImpl::Startup</code> (<code>src/LinuxTracing/TracerImpl.cpp</code>) builds two CPU sets: <code>all_cpus = 0 .. GetNumCores()-1</code>, and <code>cpuset_cpus = GetCpusetCpus(target_pid_)</code> (falls back to all CPUs if the cgroup read fails). It raises <code>RLIMIT_NOFILE</code> to the hard limit because each instrumented function costs two fds per CPU.</p>
+<table>
+  <thead><tr><th>Opener</th><th>CPU set</th><th>Kernel mechanism</th><th>Ring buffer</th></tr></thead>
+  <tbody>
+    <tr><td><code>OpenMmapTask</code></td><td>all</td><td>SW dummy + <code>mmap</code>/<code>mmap_data</code>/<code>task</code></td><td>64&nbsp;KiB</td></tr>
+    <tr><td><code>OpenUserSpaceProbes</code></td><td>cpuset</td><td>uprobe + uretprobe PMU, <code>pid=-1</code></td><td>8&nbsp;MiB shared per CPU</td></tr>
+    <tr><td><code>OpenUprobesToRecordAdditionalStackOn</code></td><td>cpuset</td><td>uprobe + user stack</td><td>64&nbsp;MiB</td></tr>
+    <tr><td><code>OpenSampling</code></td><td>cpuset</td><td><code>PERF_COUNT_SW_CPU_CLOCK</code></td><td>16&nbsp;MiB</td></tr>
+    <tr><td><code>OpenThreadNameTracepoints</code></td><td>all</td><td><code>task:task_newtask</code>, <code>task:task_rename</code></td><td>64&nbsp;KiB</td></tr>
+    <tr><td><code>OpenContextSwitchAndThreadStateTracepoints</code></td><td>all</td><td><code>sched:sched_switch</code>, <code>sched:sched_wakeup</code></td><td>2&nbsp;MiB or 64&nbsp;MiB with stacks</td></tr>
+    <tr><td><code>OpenGpuTracepoints</code></td><td>all</td><td>AMD: <code>amdgpu_cs_ioctl</code>, <code>amdgpu_sched_run_job</code>, <code>dma_fence_signaled</code></td><td>256&nbsp;KiB</td></tr>
+    <tr><td><code>OpenInstrumentedTracepoints</code></td><td>all</td><td>user-selected tracepoints</td><td>8&nbsp;MiB</td></tr>
+  </tbody>
+</table>
+<p>Errors are collected and sent as <code>ErrorsWithPerfEventOpenEvent</code> with the line “did you forget to run as root?”. GPU open failure is only logged — capture continues without GPU tracks. After opens, every fd is <code>PERF_EVENT_IOC_ENABLE</code>d in a nested loop over <code>tracing_fds_by_type_</code>.</p>
+<p>Then: maps snapshot, optional <code>WarningInstrumentingWithUprobesEvent</code> for functions not in a file mapping, system-wide thread-name snapshot, tid→pid table, optional initial thread states, optional <code>PythonSamplingThread</code>.</p>
+
+<h2>OpenUprobes: the fd tax</h2>
+<p><code>OpenUprobes</code> and <code>OpenUretprobes</code> iterate <code>cpus</code> and call <code>uprobes_retaddr_event_open</code> / <code>uretprobes_event_open</code> (or the args/retval variants) with <strong><code>pid = -1</code></strong> and <strong><code>cpu = N</code></strong>.</p>
+<pre><code>// TracerImpl::OpenUprobes
+for (int32_t cpu : cpus) {
+  fd = uprobes_retaddr_event_open(module, offset, /*pid=*/-1, cpu);
+  (*fds_per_cpu)[cpu] = fd;
+}</code></pre>
+<p>That is <strong>one uprobe fd and one uretprobe fd per CPU per function</strong>:</p>
+<pre><code>fds = 2 × F × NCPU   (plus extras if record-stack-on is used)</code></pre>
+<p>Each fd is its own <code>perf_event_open</code> of type <code>uprobe</code> (sysfs <code>/sys/bus/event_source/devices/uprobe/type</code>). Bit 0 of <code>perf_event_attr.config</code> selects uretprobe (<code>PerfEventOpen.cpp</code>). Path and file offset go in <code>config1</code>/<code>config2</code>.</p>
+<p>Uretprobe fds are committed before uprobe fds (“we support temporarily not having a uprobe associated with a uretprobe but not the opposite”). All fds on the same CPU redirect into one ring buffer via <code>PERF_EVENT_IOC_SET_OUTPUT</code> (<code>OpenRingBuffersOrRedirectOnExisting</code> — note the local typo <code>ring_bugger_fd</code>).</p>
+
+<div class="callout warn">
+  <strong>Why pid=-1, cpu=N and not pid=target, cpu=-1.</strong> <code>perf_event_open</code>’s <code>pid</code> argument is a <em>tid</em>. A single-task event does not see sibling threads already alive; <code>inherit</code> only covers children created after open; <code>inherit</code> + <code>cpu=-1</code> cannot mmap a sample ring buffer. Production therefore keeps CPU-wide fds so every thread on every core is visible. That choice is why stop cost scales with core count. Documented in PR #10; not re-measured here.
+</div>
+
+<h2>Uprobe fd lifetime</h2>
+<figure class="figure" aria-label="Uprobe fd lifetime">
+<svg viewBox="0 0 720 260" width="100%" height="auto" role="img">
+  <title>Uprobe file-descriptor lifetime on main</title>
+  <rect width="720" height="260" fill="#161b27"/>
+  <g fill="#f3eee4" font-family="ui-sans-serif,system-ui,sans-serif" font-size="12">
+    <text x="24" y="32" fill="#c4622d">ON MAIN (this tree)</text>
+    <text x="24" y="58">Open: 2×F×NCPU create_local_trace_uprobe (PMU type)</text>
+    <text x="24" y="80">Enable: ioctl PERF_EVENT_IOC_ENABLE on each fd</text>
+    <text x="24" y="102">Run: mmap ring, redirect siblings, poll</text>
+    <text x="24" y="124">Stop: ioctl DISABLE all → munmap rings → close(fd) each, in series</text>
+    <text x="24" y="146">Each close: kernel holds event_mutex across VMA walk + RCU GPs</text>
+    <text x="24" y="184" fill="#c4622d">PR #10 DIRECTION (not merged)</text>
+    <text x="24" y="208">Register once in tracefs uprobe_events; per-CPU fds are TRACEPOINT consumers</text>
+    <text x="24" y="230">Expensive unregister becomes 2×F (last close of each named probe)</text>
+  </g>
+</svg>
+<figcaption>Current <code>Shutdown</code> is sequential <code>close</code>. A <code>ParallelFor</code> on those closes cannot overlap grace periods while <code>event_mutex</code> is global. Details on the <a href="kernel-assumptions.html">kernel page</a>.</figcaption>
+</figure>
+
+<pre><code>// TracerImpl::Shutdown — the stop cost
+for (auto&amp; [fd_type, fds] : tracing_fds_by_type_) {
+  for (int fd : fds) {
+    close(fd);   // one kernel uprobe destroy per fd
+  }
+}</code></pre>
+
+<h2>Ring buffers and records</h2>
+<p><code>PerfEventRingBuffer</code> mmaps <code>1 + 2^n</code> pages (<code>perf_event_open_mmap_ring_buffer</code>). <code>ProcessOneRecord</code> switches on <code>perf_event_header.type</code>: <code>FORK</code>, <code>EXIT</code>, <code>MMAP</code>, <code>SAMPLE</code>, <code>LOST</code>, throttle. Unexpected <code>PERF_RECORD_SWITCH*</code> is logged as error — context switches are taken from <code>sched:sched_switch</code> raw samples, not the software switch records.</p>
+<p><code>ProcessSampleEventAndReturnTimestamp</code> classifies the sample by <code>PERF_EVENT_IOC_ID</code> stream id against a pile of hash sets (<code>uprobes_ids_</code>, <code>uretprobes_ids_</code>, sampling, sched, AMD GPU, …). An <code>ORBIT_CHECK</code> asserts at most one classification matches.</p>
+<p>Uprobe samples carry SP, IP, and 8 bytes of user stack (the return address about to be hijacked by the uretprobe). Uretprobe samples are empty unless return-value recording is on (then AX / ARM64 X0).</p>
+
+<h2>Ordering: PerfEventProcessor</h2>
+<p>Records from many buffers are not globally ordered. <code>DeferEvent</code> hands them to a mutex-protected vector; <code>ProcessDeferredEvents</code> moves them into <code>PerfEventProcessor</code>. That class assumes nothing older than <code>kProcessingDelayMs = 333</code> will still arrive. Older events are dropped and a <code>DiscardedPerfEvent</code> is synthesized. Visitors then run in timestamp order:</p>
+<ul>
+  <li><code>LostAndDiscardedEventVisitor</code></li>
+  <li><code>UprobesUnwindingVisitor</code> — function calls, DWARF/FP unwind, mmap → module update</li>
+  <li><code>SwitchesStatesNamesVisitor</code> — scheduling slices, thread names, thread states</li>
+  <li><code>GpuTracepointVisitor</code> — joins the three AMD events into <code>FullGpuJob</code></li>
+</ul>
+<p>Call matching is <code>UprobesFunctionCallManager</code>: a per-tid stack of open functions, popped on exit. Depth is <code>stack.size() - 1</code>. A uretprobe with no matching entry returns nullopt (lost uprobe, or capture started mid-call).</p>
+
+<h2>Sampling and unwind</h2>
+<p>DWARF: <code>stack_sample_event_open</code> copies user regs + stack (default dump size up to <code>kMaxStackSampleUserSize = 65000</code>, a kernel <code>short</code> limit documented in <code>PerfEventOpen.h</code>). Unwind is libunwindstack offline (<code>LibunwindstackUnwinder</code>).</p>
+<p>Frame pointers: <code>callchain_sample_event_open</code> uses <code>PERF_SAMPLE_CALLCHAIN</code> plus a small stack/regs dump so <code>LeafFunctionCallManager</code> can DWARF-patch the leaf. <code>exclude_callchain_kernel = true</code>.</p>
+<p>When a sample lands inside a uretprobe trampoline, <code>UprobesReturnAddressManager</code> patches the hijacked return address back so the stack looks like the target’s. The same machinery consumes user-space instrumentation trampoline ranges via <code>UserSpaceInstrumentationAddresses</code>.</p>
+
+<h2>GPU (AMD only)</h2>
+<p><code>OpenGpuTracepoints</code> opens three tracepoints system-wide. <code>GpuTracepointVisitor</code> waits until <code>amdgpu_cs_ioctl</code>, <code>amdgpu_sched_run_job</code>, and <code>dma_fence_signaled</code> share a (context, seqno, timeline) key, then emits one <code>FullGpuJob</code> with a guessed hardware start (max of schedule time and previous dma signal on that timeline). Slack of 1&nbsp;ms when assigning track depth. No Intel/NVIDIA path exists in this tree.</p>
+
+<h2>Python (py-spy)</h2>
+<p>After kernel setup, if <code>enable_python_profiling</code> is set <em>or</em> <code>IsPythonProcess(pid)</code> is true, <code>PythonSamplingThread::Create</code> attaches via <code>pyspy_new</code> / <code>pyspy_new_with_native</code> (<code>third_party/py-spy-ffi</code>, Rust, Cargo required at build). Detection is a symlink read of <code>/proc/&lt;pid&gt;/exe</code> whose filename contains <code>python</code> or <code>pypy</code>. Period defaults to the native sample period or 100&nbsp;Hz. Failure to attach is logged; capture continues. CMake skips the FFI if <code>cargo</code> is missing, which then breaks the <code>LinuxTracing</code> link line (<code>target_link_libraries(LinuxTracing PRIVATE pyspy_ffi)</code>) unless that imported target still exists.</p>
+
+<h2>What the unit tests cover</h2>
+<p><code>LinuxTracingTests</code> (see <code>src/LinuxTracing/CMakeLists.txt</code>) is offline: queues, visitors, unwind fixtures, function-call manager, mmap→module update, GPU visitor. It does <strong>not</strong> call <code>perf_event_open</code>. Integration coverage is a different binary; see the <a href="audit.html">audit</a>.</p>
+
+<nav class="pager">
+  <a href="architecture.html">← Architecture</a>
+  <a href="instrumentation.html">Instrumentation →</a>
+</nav>
+</main>
+</div>
+</body>
+</html>

--- a/docs/manual/roadmap.html
+++ b/docs/manual/roadmap.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Orbit field manual — Roadmap</title>
+<style>
+:root{--paper:#f3eee4;--paper-2:#e8e0d0;--ink:#1c1914;--mute:#5c564c;--copper:#9a3f1a;--copper-2:#c4622d;--teal:#1a4f4c;--teal-2:#2d7a74;--navy:#161b27;--navy-2:#232a3a;--code:#e8e0d0;--warn:#f4e0c4;--audit:#ead6cc;--note:#d7e6e2;--line:#cfc4b0;--rail:17.4rem}
+*{box-sizing:border-box}html{scroll-behavior:smooth}
+body{margin:0;background:var(--paper);color:var(--ink);font:16.5px/1.58 "Iowan Old Style","Palatino Linotype",Palatino,"Book Antiqua",Georgia,serif}
+.skip{position:absolute;left:-999px}.skip:focus{left:1rem;top:1rem;background:#fff;padding:.4rem;z-index:2}
+.shell{display:flex;min-height:100vh}
+.rail{width:var(--rail);flex:0 0 var(--rail);background:var(--navy);color:#d9d2c4;padding:1.35rem 1.05rem 2rem;position:sticky;top:0;height:100vh;overflow:auto}
+.rail .brand{color:#f3eee4;text-decoration:none;font:700 1.12rem/1.25 ui-sans-serif,system-ui,sans-serif;letter-spacing:.03em;display:block}
+.rail .brand span{color:var(--copper-2)}
+.rail .tag{font:12px/1.4 ui-sans-serif,system-ui,sans-serif;color:#9a9284;margin:.45rem 0 1.15rem}
+.rail ol{list-style:none;margin:0;padding:0}
+.rail a{display:block;color:#cfc6b6;text-decoration:none;padding:.36rem .5rem;border-left:3px solid transparent;font:13.5px/1.35 ui-sans-serif,system-ui,sans-serif}
+.rail a:hover{color:#fff;background:var(--navy-2)}
+.rail a.current{color:#fff;border-left-color:var(--copper-2);background:var(--navy-2)}
+.rail .num{color:var(--copper-2);margin-right:.35rem;font-variant-numeric:tabular-nums}
+main{flex:1;max-width:54rem;padding:2.1rem 2.3rem 4rem}
+h1,h2,h3,h4{font-family:ui-sans-serif,system-ui,"Segoe UI",sans-serif;letter-spacing:-.02em;line-height:1.25}
+h1{font-size:2.05rem;margin:0 0 .35rem;color:var(--navy)}
+h2{font-size:1.32rem;margin:2.1rem 0 .65rem;padding-top:.55rem;border-top:1px solid var(--line);color:var(--copper)}
+h3{font-size:1.06rem;margin:1.45rem 0 .45rem;color:var(--teal)}
+.lede{font-size:1.12rem;color:var(--mute)}
+.kicker{font:700 .7rem/1 ui-sans-serif,system-ui,sans-serif;letter-spacing:.16em;text-transform:uppercase;color:var(--copper);margin:0 0 .55rem}
+code,pre{font-family:ui-monospace,"SFMono-Regular",Menlo,Consolas,monospace;font-size:.86em}
+code{background:var(--paper-2);padding:.07em .32em;border-radius:3px}
+pre{background:var(--navy);color:var(--code);padding:1rem 1.1rem;overflow:auto;border-radius:4px;line-height:1.45}
+pre code{background:none;padding:0;color:inherit}
+.figure{background:var(--navy);border-radius:6px;padding:1rem 1rem .55rem;margin:1.15rem 0 1.5rem}
+.figure figcaption{color:#9a9284;font:12.5px/1.4 ui-sans-serif,system-ui,sans-serif;margin-top:.45rem}
+.callout{border-left:4px solid var(--teal-2);background:var(--note);padding:.75rem 1rem;margin:1.05rem 0}
+.callout.warn{border-color:var(--copper);background:var(--warn)}
+.callout.audit{border-color:#7a2e1a;background:var(--audit)}
+.callout strong{font-family:ui-sans-serif,system-ui,sans-serif}
+table{border-collapse:collapse;width:100%;font-size:.92rem;margin:1rem 0 1.35rem}
+th,td{border-bottom:1px solid var(--line);padding:.42rem .48rem;text-align:left;vertical-align:top}
+th{font:700 .72rem/1.3 ui-sans-serif,system-ui,sans-serif;text-transform:uppercase;letter-spacing:.06em;color:var(--mute)}
+.pager{display:flex;justify-content:space-between;gap:1rem;margin-top:2.4rem;padding-top:1rem;border-top:1px solid var(--line);font:14px/1.4 ui-sans-serif,system-ui,sans-serif}
+.pager a{color:var(--teal)}
+ul,ol{padding-left:1.2rem}li{margin:.26rem 0}
+a{color:var(--teal)}
+.pri{font:700 .7rem/1 ui-sans-serif,system-ui,sans-serif;letter-spacing:.08em;text-transform:uppercase;color:var(--copper-2)}
+@media(max-width:860px){.shell{display:block}.rail{position:relative;height:auto;width:auto}}
+</style>
+</head>
+<body>
+<a class="skip" href="#main">Skip to content</a>
+<div class="shell">
+<aside class="rail" aria-label="Manual">
+  <a class="brand" href="index.html">Orbit <span>field manual</span></a>
+  <p class="tag">Architecture + audit<br>tree at <code>96b2714</code></p>
+  <ol>
+    <li><a href="index.html"><span class="num">01</span>Overview</a></li>
+    <li><a href="architecture.html"><span class="num">02</span>Architecture</a></li>
+    <li><a href="linux-tracing.html"><span class="num">03</span>Linux tracing</a></li>
+    <li><a href="instrumentation.html"><span class="num">04</span>Instrumentation</a></li>
+    <li><a href="client-ui.html"><span class="num">05</span>Client UI</a></li>
+    <li><a href="symbols-modules.html"><span class="num">06</span>Symbols &amp; modules</a></li>
+    <li><a href="kernel-assumptions.html"><span class="num">07</span>Kernel assumptions</a></li>
+    <li><a href="audit.html"><span class="num">08</span>Audit</a></li>
+    <li><a class="current" href="roadmap.html"><span class="num">09</span>Roadmap</a></li>
+  </ol>
+</aside>
+<main id="main">
+<p class="kicker">What to fix · what to add · why</p>
+<h1>Roadmap</h1>
+<p class="lede">Priorities follow the product that exists: a Linux collector driven by a Qt viewer, with dynamic timers as the differentiator. Items that only make a leftover Stadia path prettier are last.</p>
+
+<h2><span class="pri">P0</span> — fix the collector contract</h2>
+<h3>Land a fast uprobe teardown</h3>
+<p>Merge the intent of PR #10: one tracefs registration per function, per-CPU fds as TRACEPOINT consumers, still close everything on stop. Keep the opt-in bench. Until this lands, kernel uprobes remain the “slower” method the UI apologizes for, and high-core machines punish Hook count at stop. Do not ship ParallelFor-on-close as the fix.</p>
+<h3>Capability probe at OrbitService start</h3>
+<p>Before any capture, log and expose: uprobe PMU present?, tracefs vs debugfs readable?, <code>perf_event_paranoid</code>, effective RLIMIT_NOFILE, cgroup v1/v2, user-space instrumentation available (arch + lib present). Surface this in the connection dialog. Fail <code>uprobe_type()</code> as an error event, not an exception.</p>
+<h3>Read tracefs first</h3>
+<p><code>GetTracepointId</code>: try <code>/sys/kernel/tracing/events/...</code> then debugfs. Same for any future <code>uprobe_events</code> writer. This is a small patch that restores sched/GPU on distros that never mount debugfs for unprivileged users (the service is root, but some environments only have tracefs).</p>
+
+<h2><span class="pri">P1</span> — make tests tell the truth</h2>
+<ul>
+  <li>Document a privileged job (self-hosted or sudo on a VM with <code>CONFIG_UPROBE_EVENTS</code>) that runs <code>LinuxTracingIntegrationTests</code> without <code>-E IntegrationTest</code>.</li>
+  <li>Replace <code>CheckIsStadiaInstance</code> with “AMD GPU tracepoints exist” so <code>GpuJobs</code> can run on a desktop.</li>
+  <li>Add a test that user-space failure falls back to uprobes for those function ids.</li>
+  <li>Implement or delete <code>OnThreadStateSliceCallstack</code> coverage; set thread-state pid to the real pid.</li>
+  <li>Align CI with the README: Conan 2 or system packages, not both undocumented. Bump Actions to v4.</li>
+  <li>If <code>cargo</code> is missing, do not make <code>LinuxTracing</code> hard-link <code>pyspy_ffi</code>; stub the target.</li>
+</ul>
+
+<h2><span class="pri">P1</span> — design improvements (existing paths)</h2>
+<ul>
+  <li><strong>cgroup v2 cpuset.</strong> Teach <code>GetCpusetCpus</code> the unified hierarchy so fd count matches the quota. Memory tracks should read the same.</li>
+  <li><strong>Watchdog vs cgroup memory.max.</strong> Half of host RAM is the wrong cap in Docker/k8s.</li>
+  <li><strong>Per-function uprobe errors</strong> in the capture log, not one boolean.</li>
+  <li><strong>Configurable reorder delay</strong> or flush-on-stop that drains below 333&nbsp;ms once buffers are disabled.</li>
+  <li><strong>Weighted poll.</strong> The TODO in <code>Run</code> is right: stack samples cost more than sched events.</li>
+  <li><strong>Reuse or forbid.</strong> Make <code>TracingHandler</code> reset-able, or name it <code>TracingSession</code> and construct per capture (it already is constructed in <code>DoCapture</code> — the comment is leftover fear from an older lifetime).</li>
+  <li><strong>Python:</strong> default off unless the user checks a box; detect via <code>/proc/pid/maps</code> for <code>libpython</code>, not the exe name. Add a unit test with a fake FFI.</li>
+</ul>
+
+<h2><span class="pri">P2</span> — features worth adding</h2>
+<p>Grounded in what the UI already almost does:</p>
+<table>
+  <thead><tr><th>Feature</th><th>Why it fits</th></tr></thead>
+  <tbody>
+    <tr><td>Live “kernel can / cannot” badge in the session dialog</td><td>Stops the “I hooked 40 functions and got nothing” loop.</td></tr>
+    <tr><td>Mid-capture hook of newly <code>dlopen</code>ed modules</td><td>Maps updates already exist; <code>OpenUserSpaceProbes</code> is start-only.</td></tr>
+    <tr><td>eBPF fallback / companion for uprobes on kernels where PMU close is painful</td><td>Same product (dynamic timers) without the fd tax. Large; only after the tracefs-once fix is measured.</td></tr>
+    <tr><td>Intel/NVIDIA GPU timelines</td><td>The track types exist; only AMD tracepoints are wired. i915/drm or NVTX-as-producer would reuse <code>GpuTrack</code>.</td></tr>
+    <tr><td>Frame tracks for manual API scopes</td><td>Already a filed TODO (<code>b/169554463</code>); games that only have <code>ORBIT_SCOPE</code> need it.</td></tr>
+    <tr><td>Disable sampling from the options dialog</td><td>Checkbox exists and is hidden. Useful when only timers matter.</td></tr>
+    <tr><td>ARM64 user-space trampolines — or an honest UI</td><td>Either implement <code>StubArm64</code> for real, or hide the Orbit method on aarch64 and default to uprobes.</td></tr>
+    <tr><td>Python + native stacks as first-class tracks</td><td>The FFI is in; the UI still treats them like ordinary samples. A GIL-held bar would match Orbit’s thread-state story.</td></tr>
+    <tr><td>Capture-file streaming / incremental save</td><td>Watchdog kills long captures. Writing the <code>ORBT</code> section as it goes would make “service OOM” less fatal.</td></tr>
+    <tr><td>Windows dynamic instrumentation (or delete the promise)</td><td>MinHook is already in <code>third_party/minhook</code>. Either use it or keep the README’s “deprecated” line louder in the UI.</td></tr>
+  </tbody>
+</table>
+
+<h2><span class="pri">P3</span> — hygiene</h2>
+<ul>
+  <li>Gate <code>PrintInstanceVersions</code> cloudcast reads on the files existing, or drop them. Same for minidump path — use a flag.</li>
+  <li>Move GGP binaries behind <code>WITH_GGP</code> (default off) or delete if unused.</li>
+  <li>Strip copybara comments from the public fork, or keep them only if Google sync is still happening.</li>
+  <li>Fix <code>building_arm64.md</code> wording (uprobes ≠ trampolines).</li>
+  <li>Replace <code>DoZoom</code> global; peel a <code>CaptureController</code> out of <code>OrbitApp</code> as the existing comment asks.</li>
+  <li>Producer socket under <code>/run/orbit/</code> with explicit mode, not world-visible <code>/tmp</code>.</li>
+</ul>
+
+<h2>Suggested order of work</h2>
+<ol>
+  <li>Tracefs fallback + sysfs probes that cannot throw (days of work, high leverage).</li>
+  <li>Finish and merge the tracefs-once uprobe registration; run the bench on a real machine; paste numbers into the existing HTML report on that branch.</li>
+  <li>One privileged CI job or a documented nightly for integration tests.</li>
+  <li>cgroup v2 + watchdog that understands containers (Raspberry Pi / Docker users are already in this fork’s README).</li>
+  <li>Python as an opt-in track, FFI stub when Cargo is absent.</li>
+  <li>Then features (mid-capture hooks, non-AMD GPU, API frame tracks).</li>
+</ol>
+
+<div class="callout">
+  <strong>What not to do first.</strong> A Windows rewrite, a new capture-file version, or a track-hierarchy refactor will not make Hook/Stop trustworthy on Linux. The collector’s kernel contract is the product.
+</div>
+
+<nav class="pager">
+  <a href="audit.html">← Audit</a>
+  <span></span>
+</nav>
+</main>
+</div>
+</body>
+</html>

--- a/docs/manual/symbols-modules.html
+++ b/docs/manual/symbols-modules.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Orbit field manual — Symbols &amp; modules</title>
+<style>
+:root{--paper:#f3eee4;--paper-2:#e8e0d0;--ink:#1c1914;--mute:#5c564c;--copper:#9a3f1a;--copper-2:#c4622d;--teal:#1a4f4c;--teal-2:#2d7a74;--navy:#161b27;--navy-2:#232a3a;--code:#e8e0d0;--warn:#f4e0c4;--audit:#ead6cc;--note:#d7e6e2;--line:#cfc4b0;--rail:17.4rem}
+*{box-sizing:border-box}html{scroll-behavior:smooth}
+body{margin:0;background:var(--paper);color:var(--ink);font:16.5px/1.58 "Iowan Old Style","Palatino Linotype",Palatino,"Book Antiqua",Georgia,serif}
+.skip{position:absolute;left:-999px}.skip:focus{left:1rem;top:1rem;background:#fff;padding:.4rem;z-index:2}
+.shell{display:flex;min-height:100vh}
+.rail{width:var(--rail);flex:0 0 var(--rail);background:var(--navy);color:#d9d2c4;padding:1.35rem 1.05rem 2rem;position:sticky;top:0;height:100vh;overflow:auto}
+.rail .brand{color:#f3eee4;text-decoration:none;font:700 1.12rem/1.25 ui-sans-serif,system-ui,sans-serif;letter-spacing:.03em;display:block}
+.rail .brand span{color:var(--copper-2)}
+.rail .tag{font:12px/1.4 ui-sans-serif,system-ui,sans-serif;color:#9a9284;margin:.45rem 0 1.15rem}
+.rail ol{list-style:none;margin:0;padding:0}
+.rail a{display:block;color:#cfc6b6;text-decoration:none;padding:.36rem .5rem;border-left:3px solid transparent;font:13.5px/1.35 ui-sans-serif,system-ui,sans-serif}
+.rail a:hover{color:#fff;background:var(--navy-2)}
+.rail a.current{color:#fff;border-left-color:var(--copper-2);background:var(--navy-2)}
+.rail .num{color:var(--copper-2);margin-right:.35rem;font-variant-numeric:tabular-nums}
+main{flex:1;max-width:54rem;padding:2.1rem 2.3rem 4rem}
+h1,h2,h3,h4{font-family:ui-sans-serif,system-ui,"Segoe UI",sans-serif;letter-spacing:-.02em;line-height:1.25}
+h1{font-size:2.05rem;margin:0 0 .35rem;color:var(--navy)}
+h2{font-size:1.32rem;margin:2.1rem 0 .65rem;padding-top:.55rem;border-top:1px solid var(--line);color:var(--copper)}
+h3{font-size:1.06rem;margin:1.45rem 0 .45rem;color:var(--teal)}
+.lede{font-size:1.12rem;color:var(--mute)}
+.kicker{font:700 .7rem/1 ui-sans-serif,system-ui,sans-serif;letter-spacing:.16em;text-transform:uppercase;color:var(--copper);margin:0 0 .55rem}
+code,pre{font-family:ui-monospace,"SFMono-Regular",Menlo,Consolas,monospace;font-size:.86em}
+code{background:var(--paper-2);padding:.07em .32em;border-radius:3px}
+pre{background:var(--navy);color:var(--code);padding:1rem 1.1rem;overflow:auto;border-radius:4px;line-height:1.45}
+pre code{background:none;padding:0;color:inherit}
+.figure{background:var(--navy);border-radius:6px;padding:1rem 1rem .55rem;margin:1.15rem 0 1.5rem}
+.figure figcaption{color:#9a9284;font:12.5px/1.4 ui-sans-serif,system-ui,sans-serif;margin-top:.45rem}
+.callout{border-left:4px solid var(--teal-2);background:var(--note);padding:.75rem 1rem;margin:1.05rem 0}
+.callout.warn{border-color:var(--copper);background:var(--warn)}
+.callout.audit{border-color:#7a2e1a;background:var(--audit)}
+.callout strong{font-family:ui-sans-serif,system-ui,sans-serif}
+table{border-collapse:collapse;width:100%;font-size:.92rem;margin:1rem 0 1.35rem}
+th,td{border-bottom:1px solid var(--line);padding:.42rem .48rem;text-align:left;vertical-align:top}
+th{font:700 .72rem/1.3 ui-sans-serif,system-ui,sans-serif;text-transform:uppercase;letter-spacing:.06em;color:var(--mute)}
+.pager{display:flex;justify-content:space-between;gap:1rem;margin-top:2.4rem;padding-top:1rem;border-top:1px solid var(--line);font:14px/1.4 ui-sans-serif,system-ui,sans-serif}
+.pager a{color:var(--teal)}
+ul,ol{padding-left:1.2rem}li{margin:.26rem 0}
+a{color:var(--teal)}
+@media(max-width:860px){.shell{display:block}.rail{position:relative;height:auto;width:auto}}
+</style>
+</head>
+<body>
+<a class="skip" href="#main">Skip to content</a>
+<div class="shell">
+<aside class="rail" aria-label="Manual">
+  <a class="brand" href="index.html">Orbit <span>field manual</span></a>
+  <p class="tag">Architecture + audit<br>tree at <code>96b2714</code></p>
+  <ol>
+    <li><a href="index.html"><span class="num">01</span>Overview</a></li>
+    <li><a href="architecture.html"><span class="num">02</span>Architecture</a></li>
+    <li><a href="linux-tracing.html"><span class="num">03</span>Linux tracing</a></li>
+    <li><a href="instrumentation.html"><span class="num">04</span>Instrumentation</a></li>
+    <li><a href="client-ui.html"><span class="num">05</span>Client UI</a></li>
+    <li><a class="current" href="symbols-modules.html"><span class="num">06</span>Symbols &amp; modules</a></li>
+    <li><a href="kernel-assumptions.html"><span class="num">07</span>Kernel assumptions</a></li>
+    <li><a href="audit.html"><span class="num">08</span>Audit</a></li>
+    <li><a href="roadmap.html"><span class="num">09</span>Roadmap</a></li>
+  </ol>
+</aside>
+<main id="main">
+<p class="kicker">ELF · DWARF · PE · PDB · mmap updates</p>
+<h1>Symbols and modules</h1>
+<p class="lede">Hooking needs a file offset. Sampling needs a virtual address. The UI needs a name. Those three numbers come from different parsers that all have to agree on load bias.</p>
+
+<h2>Object files</h2>
+<p><code>orbit_object_utils::CreateObjectFile</code> (<code>src/ObjectUtils/ObjectFile.cpp</code>) dispatches on LLVM’s object-file kind:</p>
+<ul>
+  <li><code>ElfFile</code> — ELF, DWARF, GNU build-id, .symtab / .dynsym, .gnu_debuglink, .eh_frame ranges</li>
+  <li><code>CoffFile</code> — PE/COFF, export table, debug directory pointing at a PDB</li>
+  <li><code>PdbFile</code> — PDB via LLVM (<code>PdbFileLlvm</code>) or Windows DIA (<code>PdbFileDia</code>)</li>
+</ul>
+<p><code>ObjectFile</code> explains load bias carefully: ELF symbols are relative to a virtual zero that is not always the first <code>PT_LOAD</code>; PE uses <code>ImageBase</code>. <code>GetExecutableSegmentOffset</code> is the in-memory offset of <code>.text</code>. For ELF that usually matches the file offset; for PE it often does not — which is why uprobes (file offset) and sampling (absolute VA) go through <code>ModuleUtils/VirtualAndAbsoluteAddresses.h</code>.</p>
+<p>Fallback symbols: if DWARF/PDB is missing, <code>LoadDynamicLinkingSymbolsAndUnwindRangesAsSymbols</code> / <code>LoadFallbackSymbolsFromFile</code> still give the Functions tab something to hook (exports, dynsym). This fork’s README commit “Don’t discard symbols with no build-id” is about keeping those modules visible.</p>
+
+<h2>SymbolHelper and SymbolLoader</h2>
+<p><code>SymbolHelper</code> searches, in order-ish: cache directory, user additional paths (<code>--additional_symbol_paths</code>), structured debug directories (<code>/usr/lib/debug</code> style), and — still — Stadia SDK paths:</p>
+<pre><code>GGP_SDK_PATH/sysroot/usr/lib/debug
+// plus a parent-path heuristic tagged SymbolSource::kLocalStadiaSdk</code></pre>
+<p><code>SymbolLoader</code> (owned by <code>OrbitApp</code>) is the async orchestrator:</p>
+<ol>
+  <li><code>RetrieveModuleAndLoadSymbols</code> tries real debug symbols.</li>
+  <li>On failure, <code>RetrieveModuleItselfAndLoadFallbackSymbols</code>.</li>
+  <li>Remote: download the file from the instance via <code>DownloadFileFromInstance</code> (SSH/SFTP), unless <code>--disable_instance_symbols</code>.</li>
+  <li>Optional Microsoft symbol server (<code>RemoteSymbolProvider/MicrosoftSymbolServerSymbolProvider</code>) behind <code>--symbol_store_support</code>.</li>
+  <li><code>--enable_unsafe_symbols</code> allows a file whose build-id does not match.</li>
+  <li><code>--auto_symbol_loading</code> (default true) kicks this off as modules appear; the flag text warns that Orbit can go unresponsive.</li>
+</ol>
+<p><code>ggpvlk.so</code> is still prioritized first in the load queue (<code>OrbitApp.cpp</code>, <code>kGgpVlkModulePathSubstring</code>) so a Stadia Vulkan ICD gets symbols before the game — leftover, harmless if the module is absent.</p>
+
+<h2>Module list and updates</h2>
+<p>At capture start, <code>TracerImpl::Startup</code> reads <code>/proc/&lt;pid&gt;/maps</code> via <code>ModuleUtils/ReadLinuxModules.h</code> and emits <code>ModulesSnapshot</code>.</p>
+<p>During capture, <code>OpenMmapTask</code> records executable and non-executable mmaps. <code>ProcessMmapEventAndReturnTimestamp</code> keeps only the target pid and timestamps after enable. <code>UprobesUnwindingVisitor</code> turns those into <code>ModuleUpdateEvent</code> and refreshes libunwindstack maps. Integration test <code>ModuleUpdateOnDlopen</code> covers the happy path (needs <code>perf_event_paranoid ≤ 0</code> or root).</p>
+<p>Windows uses Toolhelp <code>ListModules</code>, then ETW <code>ListModulesEtw</code> if that is empty.</p>
+
+<h2>Addresses: three numbers</h2>
+<table>
+  <thead><tr><th>Number</th><th>Who uses it</th></tr></thead>
+  <tbody>
+    <tr><td>File offset</td><td>uprobe <code>config2</code> / trampoline patch site</td></tr>
+    <tr><td>Virtual address in module (RVA / ELF st_value)</td><td>symbol tables, Functions tab</td></tr>
+    <tr><td>Absolute address in the process</td><td>samples, mmap, stop-unwinding-at, Wine dispatcher</td></tr>
+  </tbody>
+</table>
+<p>Conversion is <code>SymbolVirtualAddressToAbsoluteAddress(addr, module_start, load_bias, executable_segment_offset)</code>. Getting any of those four wrong produces hooks that never fire or samples that never symbolize. The PE-in-anonymous-map case is the documented footgun: the file offset is in a <code>r--</code> header map, the runtime VA is in an anonymous <code>r-x</code> map.</p>
+
+<h2>Source and disassembly</h2>
+<p>Once symbols include line info, <code>CodeViewer</code> / <code>CodeReport</code> / <code>SyntaxHighlighter</code> show source. Source path remapping is <code>src/SourcePathsMapping</code>. Disassembly uses Capstone (also used to size trampolines). This path was not exercised in this review.</p>
+
+<div class="callout">
+  <strong>Build-id is the join key.</strong> Cache files, instance downloads, and “is this the right PDB?” all go through build-id (or PE equivalent via <code>WindowsBuildIdUtils</code>). <code>--enable_unsafe_symbols</code> is the escape hatch and a good way to silently attribute samples to the wrong binary.
+</div>
+
+<nav class="pager">
+  <a href="client-ui.html">← Client UI</a>
+  <a href="kernel-assumptions.html">Kernel assumptions →</a>
+</nav>
+</main>
+</div>
+</body>
+</html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Self-contained static HTML manual + architecture review under `docs/manual/`. No profiler behavior change.

## What
Open [`docs/manual/index.html`](../blob/cursor/orbit-architecture-manual-b58c/docs/manual/index.html) as files or serve the folder. Relative nav only; inline CSS + SVG; no CDN, webfonts, or external images.

| Page | Contents |
|---|---|
| [index](../blob/cursor/orbit-architecture-manual-b58c/docs/manual/index.html) | What Orbit is, how to read the manual, process map |
| [architecture](../blob/cursor/orbit-architecture-manual-b58c/docs/manual/architecture.html) | UI / OrbitService / producers, capture start/stop, event path |
| [linux-tracing](../blob/cursor/orbit-architecture-manual-b58c/docs/manual/linux-tracing.html) | `TracerImpl`, `OpenUprobes`, ring buffers, per-CPU fds, visitors |
| [instrumentation](../blob/cursor/orbit-architecture-manual-b58c/docs/manual/instrumentation.html) | Kernel uprobes vs trampolines vs API vs py-spy |
| [client-ui](../blob/cursor/orbit-architecture-manual-b58c/docs/manual/client-ui.html) | Session, tracks, Hook, options that exist |
| [symbols-modules](../blob/cursor/orbit-architecture-manual-b58c/docs/manual/symbols-modules.html) | ELF/DWARF/PE/PDB, mmap updates, Wine/PE |
| [kernel-assumptions](../blob/cursor/orbit-architecture-manual-b58c/docs/manual/kernel-assumptions.html) | Uprobe PMU, debugfs-only `GetTracepointId`, cgroup v1, `event_mutex` / per-CPU close cost |
| [audit](../blob/cursor/orbit-architecture-manual-b58c/docs/manual/audit.html) | Shortcomings, leftovers, CI/test gaps |
| [roadmap](../blob/cursor/orbit-architecture-manual-b58c/docs/manual/roadmap.html) | Prioritized fixes and features |

## Audit (verified in tree)
- **Current `main` still does `pid=-1, cpu=N` PMU fds** (`2×F×NCPU`) and sequential `close` in `TracerImpl::Shutdown`. PR #10 / `cursor/fast-uprobe-stop-a3cf` is described as historical direction, not as merged behavior.
- `GetTracepointId` reads only `/sys/kernel/debug/tracing/events/.../id` (no tracefs fallback).
- `GetCpusetCpus` is cgroup v1; `PrintInstanceVersions` and minidump lookup still use `/usr/local/cloudcast/`.
- CI Ubuntu runs `ARGS="-E IntegrationTest"`. GPU integration tests require a Stadia (`-ggp-`) kernel.
- `uprobe_type()` uses `ReadFileToString().value()` + `std::stoul` (can throw if the PMU is missing).

## What was not run
This VM: Linux 6.12.94+, no uprobe PMU, no `uprobe_events`, `perf_event_paranoid=2`, no Qt5. No OrbitQt/LinuxTracing build, no integration tests, no `ORBIT_UPROBE_BENCH=1`. No invented timings.

## Hosting
```
python3 -m http.server --directory docs/manual 8080
```
GitHub Pages: publish `/docs` and open `/manual/`, or use this folder as the site root.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51044422-2a3a-4ea3-bbfc-3879392db58c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51044422-2a3a-4ea3-bbfc-3879392db58c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

