### PR TITLE
Fix all compiler warnings in first-party code

### DIFF
--- a/src/Api/Orbit.cpp
+++ b/src/Api/Orbit.cpp
@@ -124,6 +124,17 @@ void orbit_api_initialize_and_set_enabled(OrbitApiT* api,
   api->enabled = static_cast<uint32_t>(enabled);
 }
 
+// orbit_api_start and orbit_api_start_async are deprecated, but the v0 and v1 function tables are
+// part of the ABI that already-instrumented binaries rely on, so they keep pointing at them.
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif  // __GNUC__
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif  // _MSC_VER
+
 void orbit_api_initialize_v0(orbit_api_v0* api_v0) {
   api_v0->start = &orbit_api_start;
   api_v0->stop = &orbit_api_stop;
@@ -151,6 +162,13 @@ void orbit_api_initialize_v1(orbit_api_v1* api_v1) {
   api_v1->track_float = &orbit_api_track_float;
   api_v1->track_double = &orbit_api_track_double;
 }
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif  // __GNUC__
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // _MSC_VER
 
 void orbit_api_initialize_v2(orbit_api_v2* api_v2) {
   api_v2->start = &orbit_api_start_v1;

--- a/src/CaptureClient/ApiEventProcessorTest.cpp
+++ b/src/CaptureClient/ApiEventProcessorTest.cpp
@@ -34,7 +34,6 @@ using orbit_client_protos::TimerInfo;
 using google::protobuf::util::MessageDifferencer;
 using ::testing::AllOf;
 using ::testing::DoubleEq;
-using ::testing::Invoke;
 using ::testing::Property;
 using ::testing::SaveArg;
 
@@ -204,8 +203,7 @@ TEST_F(ApiEventProcessorTest, ScopesFromSameThread) {
 
   EXPECT_CALL(capture_listener_, OnTimer)
       .Times(3)
-      .WillRepeatedly(
-          Invoke([&actual_timers](const TimerInfo& timer) { actual_timers.push_back(timer); }));
+      .WillRepeatedly([&actual_timers](const TimerInfo& timer) { actual_timers.push_back(timer); });
 
   api_event_processor_.ProcessApiScopeStop(stop_2);
   api_event_processor_.ProcessApiScopeStop(stop_1);
@@ -243,8 +241,7 @@ TEST_F(ApiEventProcessorTest, ScopesFromDifferentThreads) {
 
   EXPECT_CALL(capture_listener_, OnTimer)
       .Times(2)
-      .WillRepeatedly(
-          Invoke([&actual_timers](const TimerInfo& timer) { actual_timers.push_back(timer); }));
+      .WillRepeatedly([&actual_timers](const TimerInfo& timer) { actual_timers.push_back(timer); });
 
   api_event_processor_.ProcessApiScopeStop(stop_2);
   api_event_processor_.ProcessApiScopeStop(stop_1);
@@ -282,8 +279,7 @@ TEST_F(ApiEventProcessorTest, AsyncScopes) {
 
   EXPECT_CALL(capture_listener_, OnTimer)
       .Times(3)
-      .WillRepeatedly(
-          Invoke([&actual_timers](const TimerInfo& timer) { actual_timers.push_back(timer); }));
+      .WillRepeatedly([&actual_timers](const TimerInfo& timer) { actual_timers.push_back(timer); });
 
   api_event_processor_.ProcessApiScopeStopAsync(stop_2);
   api_event_processor_.ProcessApiScopeStopAsync(stop_1);
@@ -314,7 +310,7 @@ TEST_F(ApiEventProcessorTest, AsyncScopesOverwrittenStartAndRepeatedStop) {
   orbit_client_protos::TimerInfo actual_timer;
   EXPECT_CALL(capture_listener_, OnTimer)
       .Times(1)
-      .WillRepeatedly(Invoke([&actual_timer](const TimerInfo& timer) { actual_timer = timer; }));
+      .WillRepeatedly([&actual_timer](const TimerInfo& timer) { actual_timer = timer; });
 
   api_event_processor_.ProcessApiScopeStartAsync(start0);
   api_event_processor_.ProcessApiScopeStartAsync(start1);
@@ -339,8 +335,7 @@ TEST_F(ApiEventProcessorTest, AsyncScopesWithIdsDifferingOnlyInUpperHalf) {
   std::vector<orbit_client_protos::TimerInfo> actual_timers;
   EXPECT_CALL(capture_listener_, OnTimer)
       .Times(2)
-      .WillRepeatedly(
-          Invoke([&actual_timers](const TimerInfo& timer) { actual_timers.push_back(timer); }));
+      .WillRepeatedly([&actual_timers](const TimerInfo& timer) { actual_timers.push_back(timer); });
 
   api_event_processor_.ProcessApiScopeStartAsync(start0);
   api_event_processor_.ProcessApiScopeStartAsync(start1);

--- a/src/CaptureClient/CaptureClient.cpp
+++ b/src/CaptureClient/CaptureClient.cpp
@@ -190,7 +190,7 @@ orbit_base::Future<ErrorMessageOr<CaptureListener::CaptureOutcome>> CaptureClien
     const orbit_client_data::ModuleManager& module_manager,
     const orbit_client_data::ProcessData& process_data,
     const ClientCaptureOptions& capture_options) {
-  absl::MutexLock lock(&state_mutex_);
+  absl::MutexLock lock(state_mutex_);
   if (state_ != State::kStopped) {
     return {
         ErrorMessage("Capture cannot be started, the previous capture is still "
@@ -214,7 +214,7 @@ ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureClient::CaptureSync(
   writes_done_failed_ = false;
   try_abort_ = false;
   {
-    absl::WriterMutexLock lock{&context_and_stream_mutex_};
+    absl::WriterMutexLock lock{context_and_stream_mutex_};
     ORBIT_CHECK(client_context_ == nullptr);
     ORBIT_CHECK(reader_writer_ == nullptr);
     client_context_ = std::make_unique<grpc::ClientContext>();
@@ -226,7 +226,7 @@ ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureClient::CaptureSync(
 
   bool request_write_succeeded{};
   {
-    absl::ReaderMutexLock lock{&context_and_stream_mutex_};
+    absl::ReaderMutexLock lock{context_and_stream_mutex_};
     request_write_succeeded = reader_writer_->Write(request);
     if (!request_write_succeeded) {
       reader_writer_->WritesDone();
@@ -246,7 +246,7 @@ ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureClient::CaptureSync(
     CaptureResponse response;
     bool read_succeeded{};
     {
-      absl::ReaderMutexLock lock{&context_and_stream_mutex_};
+      absl::ReaderMutexLock lock{context_and_stream_mutex_};
       read_succeeded = reader_writer_->Read(&response);
     }
     if (read_succeeded) {
@@ -283,7 +283,7 @@ ErrorMessageOr<CaptureListener::CaptureOutcome> CaptureClient::CaptureSync(
 
 bool CaptureClient::StopCapture() {
   {
-    absl::MutexLock lock(&state_mutex_);
+    absl::MutexLock lock(state_mutex_);
     if (state_ == State::kStarting) {
       ORBIT_LOG("StopCapture ignored, because it is starting and cannot be stopped at this stage.");
       return false;
@@ -299,7 +299,7 @@ bool CaptureClient::StopCapture() {
 
   bool writes_done_succeeded = false;
   {
-    absl::ReaderMutexLock lock{&context_and_stream_mutex_};
+    absl::ReaderMutexLock lock{context_and_stream_mutex_};
     ORBIT_CHECK(reader_writer_ != nullptr);
     writes_done_succeeded = reader_writer_->WritesDone();
   }
@@ -321,7 +321,7 @@ bool CaptureClient::StopCapture() {
 
 bool CaptureClient::AbortCaptureAndWait(int64_t max_wait_ms) {
   {
-    absl::ReaderMutexLock lock{&context_and_stream_mutex_};
+    absl::ReaderMutexLock lock{context_and_stream_mutex_};
     if (client_context_ == nullptr) {
       ORBIT_LOG("AbortCaptureAndWait ignored: no ClientContext to TryCancel");
       return false;
@@ -334,7 +334,7 @@ bool CaptureClient::AbortCaptureAndWait(int64_t max_wait_ms) {
   // With this wait we want to leave at least some time for FinishCapture to be called, so that
   // reader_writer_ and in particular client_context_ are destroyed before returning to the caller.
   {
-    absl::MutexLock lock(&state_mutex_);
+    absl::MutexLock lock(state_mutex_);
     state_mutex_.AwaitWithTimeout(
         absl::Condition(
             +[](State* state) { return *state == State::kStopped; }, &state_),
@@ -348,7 +348,7 @@ ErrorMessageOr<void> CaptureClient::FinishCapture() {
 
   grpc::Status status;
   {
-    absl::WriterMutexLock lock{&context_and_stream_mutex_};
+    absl::WriterMutexLock lock{context_and_stream_mutex_};
     ORBIT_CHECK(reader_writer_ != nullptr);
     status = reader_writer_->Finish();
     reader_writer_.reset();
@@ -357,7 +357,7 @@ ErrorMessageOr<void> CaptureClient::FinishCapture() {
   }
 
   {
-    absl::MutexLock lock(&state_mutex_);
+    absl::MutexLock lock(state_mutex_);
     state_ = State::kStopped;
     ORBIT_LOG("State is now kStopped");
   }
@@ -375,7 +375,7 @@ void CaptureClient::ProcessEvents(
   for (const auto& event : events) {
     capture_event_processor->ProcessEvent(event);
     if (event.event_case() == ClientCaptureEvent::kCaptureStarted) {
-      absl::MutexLock lock{&state_mutex_};
+      absl::MutexLock lock{state_mutex_};
       state_ = State::kStarted;
       ORBIT_LOG("State is now kStarted");
     }

--- a/src/CaptureClient/include/CaptureClient/CaptureClient.h
+++ b/src/CaptureClient/include/CaptureClient/CaptureClient.h
@@ -52,12 +52,12 @@ class CaptureClient {
   [[nodiscard]] bool StopCapture();
 
   [[nodiscard]] State state() const {
-    absl::MutexLock lock(&state_mutex_);
+    absl::MutexLock lock(state_mutex_);
     return state_;
   }
 
   [[nodiscard]] bool IsCapturing() const {
-    absl::MutexLock lock(&state_mutex_);
+    absl::MutexLock lock(state_mutex_);
     return state_ != State::kStopped;
   }
 

--- a/src/CaptureEventProducer/CaptureEventProducer.cpp
+++ b/src/CaptureEventProducer/CaptureEventProducer.cpp
@@ -28,13 +28,13 @@ void CaptureEventProducer::BuildAndStart(const std::shared_ptr<grpc::Channel>& c
 
 void CaptureEventProducer::ShutdownAndWait() {
   {
-    absl::WriterMutexLock lock{&shutdown_requested_mutex_};
+    absl::WriterMutexLock lock{shutdown_requested_mutex_};
     ORBIT_CHECK(!shutdown_requested_);
     shutdown_requested_ = true;
   }
 
   {
-    absl::ReaderMutexLock lock{&context_and_stream_mutex_};
+    absl::ReaderMutexLock lock{context_and_stream_mutex_};
     if (context_ != nullptr) {
       ORBIT_LOG("Attempting to disconnect from ProducerSideService as exit was requested");
       context_->TryCancel();
@@ -62,13 +62,13 @@ bool CaptureEventProducer::SendCaptureEvents(
   {
     // Acquiring the mutex just for the CHECK might seem expensive,
     // but the gRPC call that follows is orders of magnitude slower.
-    absl::ReaderMutexLock lock{&shutdown_requested_mutex_};
+    absl::ReaderMutexLock lock{shutdown_requested_mutex_};
     ORBIT_CHECK(!shutdown_requested_);
   }
 
   bool write_succeeded{};
   {
-    absl::ReaderMutexLock lock{&context_and_stream_mutex_};
+    absl::ReaderMutexLock lock{context_and_stream_mutex_};
     if (stream_ == nullptr) {
       ORBIT_ERROR("Sending BufferedCaptureEvents to ProducerSideService: not connected");
       return false;
@@ -84,7 +84,7 @@ bool CaptureEventProducer::SendCaptureEvents(
 bool CaptureEventProducer::NotifyAllEventsSent() {
   ORBIT_CHECK(producer_side_service_stub_ != nullptr);
   {
-    absl::ReaderMutexLock lock{&shutdown_requested_mutex_};
+    absl::ReaderMutexLock lock{shutdown_requested_mutex_};
     ORBIT_CHECK(!shutdown_requested_);
   }
 
@@ -92,7 +92,7 @@ bool CaptureEventProducer::NotifyAllEventsSent() {
   all_events_sent_request.mutable_all_events_sent();
   bool write_succeeded{};
   {
-    absl::ReaderMutexLock lock{&context_and_stream_mutex_};
+    absl::ReaderMutexLock lock{context_and_stream_mutex_};
     if (stream_ == nullptr) {
       ORBIT_ERROR("Sending AllEventsSent to ProducerSideService: not connected");
       return false;
@@ -113,7 +113,7 @@ void CaptureEventProducer::ConnectAndReceiveCommandsThread() {
 
   while (true) {
     {
-      absl::ReaderMutexLock lock{&shutdown_requested_mutex_};
+      absl::ReaderMutexLock lock{shutdown_requested_mutex_};
       if (shutdown_requested_) {
         break;
       }
@@ -122,7 +122,7 @@ void CaptureEventProducer::ConnectAndReceiveCommandsThread() {
     // Attempt to connect to ProducerSideService. Note that getting a stream_ != nullptr doesn't
     // mean that the service is listening nor that the connection is actually established.
     {
-      absl::WriterMutexLock lock{&context_and_stream_mutex_};
+      absl::WriterMutexLock lock{context_and_stream_mutex_};
       context_ = std::make_unique<grpc::ClientContext>();
       stream_ = producer_side_service_stub_->ReceiveCommandsAndSendEvents(context_.get());
     }
@@ -137,7 +137,7 @@ void CaptureEventProducer::ConnectAndReceiveCommandsThread() {
       shutdown_requested_mutex_.ReaderLockWhenWithTimeout(
           absl::Condition(&shutdown_requested_),
           absl::Milliseconds(static_cast<int64_t>(reconnection_delay_ms_)));
-      shutdown_requested_mutex_.ReaderUnlock();
+      shutdown_requested_mutex_.unlock_shared();
       continue;
     }
     ORBIT_LOG("Called ReceiveCommandsAndSendEvents on ProducerSideService");
@@ -146,7 +146,7 @@ void CaptureEventProducer::ConnectAndReceiveCommandsThread() {
       ReceiveCommandsAndSendEventsResponse response;
       bool read_succeeded{};
       {
-        absl::ReaderMutexLock lock{&context_and_stream_mutex_};
+        absl::ReaderMutexLock lock{context_and_stream_mutex_};
         read_succeeded = stream_->Read(&response);
       }
       if (!read_succeeded) {
@@ -162,7 +162,7 @@ void CaptureEventProducer::ConnectAndReceiveCommandsThread() {
         }
         ORBIT_LOG("Terminating call to ReceiveCommandsAndSendEvents");
         {
-          absl::WriterMutexLock lock{&context_and_stream_mutex_};
+          absl::WriterMutexLock lock{context_and_stream_mutex_};
           stream_->Finish().IgnoreError();
           context_ = nullptr;
           stream_ = nullptr;
@@ -172,7 +172,7 @@ void CaptureEventProducer::ConnectAndReceiveCommandsThread() {
         shutdown_requested_mutex_.ReaderLockWhenWithTimeout(
             absl::Condition(&shutdown_requested_),
             absl::Milliseconds(static_cast<int64_t>(reconnection_delay_ms_)));
-        shutdown_requested_mutex_.ReaderUnlock();
+        shutdown_requested_mutex_.unlock_shared();
         break;
       }
 

--- a/src/CaptureEventProducer/include/CaptureEventProducer/LockFreeBufferCaptureEventProducer.h
+++ b/src/CaptureEventProducer/include/CaptureEventProducer/LockFreeBufferCaptureEventProducer.h
@@ -68,17 +68,17 @@ class LockFreeBufferCaptureEventProducer : public CaptureEventProducer {
 
  protected:
   void OnCaptureStart(orbit_grpc_protos::CaptureOptions /*capture_options*/) override {
-    absl::MutexLock lock{&status_mutex_};
+    absl::MutexLock lock{status_mutex_};
     status_ = ProducerStatus::kShouldSendEvents;
   }
 
   void OnCaptureStop() override {
-    absl::MutexLock lock{&status_mutex_};
+    absl::MutexLock lock{status_mutex_};
     status_ = ProducerStatus::kShouldNotifyAllEventsSent;
   }
 
   void OnCaptureFinished() override {
-    absl::MutexLock lock{&status_mutex_};
+    absl::MutexLock lock{status_mutex_};
     status_ = ProducerStatus::kShouldDropEvents;
   }
 
@@ -123,7 +123,7 @@ class LockFreeBufferCaptureEventProducer : public CaptureEventProducer {
 
         ProducerStatus current_status;
         {
-          absl::MutexLock lock{&status_mutex_};
+          absl::MutexLock lock{status_mutex_};
           current_status = status_;
           if (status_ == ProducerStatus::kShouldNotifyAllEventsSent && queue_was_emptied) {
             // We are about to send AllEventsSent: update status_ while we hold the mutex.

--- a/src/CaptureFile/BufferOutputStream.cpp
+++ b/src/CaptureFile/BufferOutputStream.cpp
@@ -15,7 +15,7 @@ namespace orbit_capture_file {
 bool BufferOutputStream::Write(const void* data, int size) {
   ORBIT_CHECK(data != nullptr);
   ORBIT_CHECK(size >= 0);
-  absl::MutexLock lock{&mutex_};
+  absl::MutexLock lock{mutex_};
 
   size_t old_size = buffer_.size();
   size_t new_size = old_size + size;
@@ -28,7 +28,7 @@ bool BufferOutputStream::Write(const void* data, int size) {
 }
 
 std::vector<unsigned char> BufferOutputStream::TakeBuffer() {
-  absl::MutexLock lock{&mutex_};
+  absl::MutexLock lock{mutex_};
 
   auto output_buffer = std::move(buffer_);
 

--- a/src/CaptureFile/ProtoSectionInputStreamImpl.cpp
+++ b/src/CaptureFile/ProtoSectionInputStreamImpl.cpp
@@ -49,7 +49,10 @@ ErrorMessageOr<void> ProtoSectionInputStreamImpl::ReadMessage(google::protobuf::
         ErrorMessage{"Unexpected end of section while reading the message"});
   }
 
-  message->ParseFromArray(buf.get(), message_size);
+  if (!message->ParseFromArray(buf.get(), message_size)) {
+    return ErrorMessage{
+        absl::StrFormat("Unable to parse the message of size %d in the section", message_size)};
+  }
 
   if (message->ByteSizeLong() != message_size) {
     return ErrorMessage{absl::StrFormat(

--- a/src/CaptureServiceBase/CaptureServiceBase.cpp
+++ b/src/CaptureServiceBase/CaptureServiceBase.cpp
@@ -38,7 +38,7 @@ CaptureServiceBase::CaptureInitializationResult CaptureServiceBase::InitializeCa
   ORBIT_CHECK(client_capture_event_collector != nullptr);
 
   {
-    absl::MutexLock lock(&capture_mutex_);
+    absl::MutexLock lock(capture_mutex_);
     if (is_capturing_) {
       return CaptureInitializationResult::kAlreadyInProgress;
     }
@@ -55,7 +55,7 @@ void CaptureServiceBase::TerminateCapture() {
   client_capture_event_collector_ = nullptr;
   capture_start_timestamp_ns_ = 0;
 
-  absl::MutexLock lock(&capture_mutex_);
+  absl::MutexLock lock(capture_mutex_);
   is_capturing_ = false;
 }
 

--- a/src/ClientData/CaptureData.cpp
+++ b/src/ClientData/CaptureData.cpp
@@ -73,7 +73,7 @@ CaptureData::CaptureData(CaptureStarted capture_started,
 void CaptureData::ForEachThreadStateSliceIntersectingTimeRange(
     uint32_t thread_id, uint64_t min_timestamp, uint64_t max_timestamp,
     const std::function<void(const ThreadStateSliceInfo&)>& action) const {
-  absl::MutexLock lock{&thread_state_slices_mutex_};
+  absl::MutexLock lock{thread_state_slices_mutex_};
   auto tid_thread_state_slices_it = thread_state_slices_.find(thread_id);
   if (tid_thread_state_slices_it == thread_state_slices_.end()) {
     return;
@@ -96,7 +96,7 @@ void CaptureData::ForEachThreadStateSliceIntersectingTimeRange(
 void CaptureData::ForEachThreadStateSliceIntersectingTimeRangeDiscretized(
     uint32_t thread_id, uint64_t min_timestamp, uint64_t max_timestamp, uint32_t resolution,
     const std::function<void(const ThreadStateSliceInfo&)>& action) const {
-  absl::MutexLock lock{&thread_state_slices_mutex_};
+  absl::MutexLock lock{thread_state_slices_mutex_};
   auto tid_thread_state_slices_it = thread_state_slices_.find(thread_id);
   if (tid_thread_state_slices_it == thread_state_slices_.end()) {
     return;
@@ -350,7 +350,7 @@ std::unique_ptr<const ScopeStatsCollection> CaptureData::CreateScopeStatsCollect
 
 [[nodiscard]] std::optional<ThreadStateSliceInfo>
 CaptureData::FindThreadStateSliceInfoFromTimestamp(int64_t thread_id, uint64_t timestamp) const {
-  absl::MutexLock lock{&thread_state_slices_mutex_};
+  absl::MutexLock lock{thread_state_slices_mutex_};
   if (!thread_state_slices_.contains(thread_id)) {
     return std::nullopt;
   }

--- a/src/ClientData/ModuleData.cpp
+++ b/src/ClientData/ModuleData.cpp
@@ -23,47 +23,47 @@ namespace orbit_client_data {
 ModuleData::ModuleData(ModuleInfo module_info) : module_info_{std::move(module_info)} {}
 
 const std::string& ModuleData::name() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return module_info_.name();
 }
 
 const std::string& ModuleData::file_path() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return module_info_.file_path();
 }
 
 uint64_t ModuleData::file_size() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return module_info_.file_size();
 }
 
 const std::string& ModuleData::build_id() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return module_info_.build_id();
 }
 
 uint64_t ModuleData::load_bias() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return module_info_.load_bias();
 }
 
 uint64_t ModuleData::executable_segment_offset() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return module_info_.executable_segment_offset();
 }
 
 ModuleInfo::ObjectFileType ModuleData::object_file_type() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return module_info_.object_file_type();
 }
 
 std::vector<ModuleInfo::ObjectSegment> ModuleData::GetObjectSegments() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return {module_info_.object_segments().begin(), module_info_.object_segments().end()};
 }
 
 uint64_t ModuleData::ConvertFromVirtualAddressToOffsetInFile(uint64_t virtual_address) const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
 
   if (module_info_.object_file_type() == orbit_grpc_protos::ModuleInfo::kElfFile) {
     // For ELF files, we define the load bias as the difference between the executable loadable
@@ -88,7 +88,7 @@ uint64_t ModuleData::ConvertFromVirtualAddressToOffsetInFile(uint64_t virtual_ad
 }
 
 uint64_t ModuleData::ConvertFromOffsetInFileToVirtualAddress(uint64_t offset_in_file) const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
 
   if (module_info_.object_file_type() == orbit_grpc_protos::ModuleInfo::kElfFile) {
     return offset_in_file + module_info_.load_bias();
@@ -113,7 +113,7 @@ bool ModuleData::NeedsUpdate(const orbit_grpc_protos::ModuleInfo& new_module_inf
 }
 
 bool ModuleData::UpdateIfChangedAndUnload(ModuleInfo new_module_info) {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
 
   ORBIT_CHECK(module_info_.file_path() == new_module_info.file_path());
   ORBIT_CHECK(module_info_.build_id() == new_module_info.build_id());
@@ -143,7 +143,7 @@ bool ModuleData::UpdateIfChangedAndUnload(ModuleInfo new_module_info) {
 }
 
 bool ModuleData::UpdateIfChangedAndNotLoaded(orbit_grpc_protos::ModuleInfo new_module_info) {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
 
   ORBIT_CHECK(module_info_.file_path() == new_module_info.file_path());
   ORBIT_CHECK(module_info_.build_id() == new_module_info.build_id());
@@ -162,7 +162,7 @@ bool ModuleData::UpdateIfChangedAndNotLoaded(orbit_grpc_protos::ModuleInfo new_m
 
 const FunctionInfo* ModuleData::FindFunctionByVirtualAddress(uint64_t virtual_address,
                                                              bool is_exact) const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   if (functions_.empty()) return nullptr;
 
   auto cache_it = absolute_address_to_function_info_cache_.find(virtual_address);
@@ -197,18 +197,18 @@ const FunctionInfo* ModuleData::FindFunctionByVirtualAddress(uint64_t virtual_ad
 }
 
 const FunctionInfo* ModuleData::FindFunctionFromHash(uint64_t hash) const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return hash_to_function_map_.contains(hash) ? hash_to_function_map_.at(hash) : nullptr;
 }
 
 const FunctionInfo* ModuleData::FindFunctionFromPrettyName(std::string_view pretty_name) const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   auto it = name_to_function_info_map_.find(pretty_name);
   return it != name_to_function_info_map_.end() ? it->second : nullptr;
 }
 
 std::vector<const FunctionInfo*> ModuleData::GetFunctions() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   std::vector<const FunctionInfo*> result;
   result.reserve(functions_.size());
   for (const auto& pair : functions_) {
@@ -218,28 +218,28 @@ std::vector<const FunctionInfo*> ModuleData::GetFunctions() const {
 }
 
 ModuleData::SymbolCompleteness ModuleData::GetLoadedSymbolsCompleteness() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return loaded_symbols_completeness_;
 }
 
 bool ModuleData::AreDebugSymbolsLoaded() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return loaded_symbols_completeness_ >= SymbolCompleteness::kDebugSymbols;
 }
 
 bool ModuleData::AreAtLeastFallbackSymbolsLoaded() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return loaded_symbols_completeness_ >= SymbolCompleteness::kDynamicLinkingAndUnwindInfo;
 }
 
 void ModuleData::AddSymbols(const orbit_grpc_protos::ModuleSymbols& module_symbols) {
   ORBIT_SCOPE_FUNCTION;
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   AddSymbolsInternal(module_symbols, SymbolCompleteness::kDebugSymbols);
 }
 
 void ModuleData::AddFallbackSymbols(const orbit_grpc_protos::ModuleSymbols& module_symbols) {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   AddSymbolsInternal(module_symbols, SymbolCompleteness::kDynamicLinkingAndUnwindInfo);
 }
 

--- a/src/ClientData/ModuleIdentifierProvider.cpp
+++ b/src/ClientData/ModuleIdentifierProvider.cpp
@@ -13,7 +13,7 @@ namespace orbit_client_data {
 
 ModuleIdentifier ModuleIdentifierProvider::CreateModuleIdentifier(
     const ModulePathAndBuildId& module_path_and_build_id) {
-  absl::WriterMutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(mutex_);
 
   // We are using the current size as next id. If insertion does not take place, size remains the
   // same and we are not wasting ids.
@@ -26,7 +26,7 @@ ModuleIdentifier ModuleIdentifierProvider::CreateModuleIdentifier(
 
 std::optional<ModuleIdentifier> ModuleIdentifierProvider::GetModuleIdentifier(
     const ModulePathAndBuildId& module_path_and_build_id) const {
-  absl::ReaderMutexLock lock(&mutex_);
+  absl::ReaderMutexLock lock(mutex_);
   const auto it = module_identifier_map_.find(module_path_and_build_id);
   if (it == module_identifier_map_.end()) return std::nullopt;
   return it->second;
@@ -34,7 +34,7 @@ std::optional<ModuleIdentifier> ModuleIdentifierProvider::GetModuleIdentifier(
 
 std::optional<ModulePathAndBuildId> ModuleIdentifierProvider::GetModulePathAndBuildId(
     ModuleIdentifier module_identifier) const {
-  absl::ReaderMutexLock lock(&mutex_);
+  absl::ReaderMutexLock lock(mutex_);
 
   for (const auto& [current_module_path_and_build_id, current_module_identifier] :
        module_identifier_map_) {

--- a/src/ClientData/ModuleManager.cpp
+++ b/src/ClientData/ModuleManager.cpp
@@ -24,7 +24,7 @@ namespace orbit_client_data {
 
 std::vector<ModuleData*> ModuleManager::AddOrUpdateModules(
     absl::Span<const orbit_grpc_protos::ModuleInfo> module_infos) {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
 
   std::vector<ModuleData*> unloaded_modules;
 
@@ -54,7 +54,7 @@ std::vector<ModuleData*> ModuleManager::AddOrUpdateModules(
 
 std::vector<ModuleData*> ModuleManager::AddOrUpdateNotLoadedModules(
     absl::Span<const orbit_grpc_protos::ModuleInfo> module_infos) {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
 
   std::vector<ModuleData*> not_updated_modules;
 
@@ -85,7 +85,7 @@ std::vector<ModuleData*> ModuleManager::AddOrUpdateNotLoadedModules(
 
 const ModuleData* ModuleManager::GetModuleByModuleInMemoryAndAbsoluteAddress(
     const ModuleInMemory& module_in_memory, uint64_t absolute_address) const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   auto cache_it = absolute_address_to_module_data_cache_.find(absolute_address);
   if (cache_it != absolute_address_to_module_data_cache_.end()) {
     return cache_it->second;
@@ -111,7 +111,7 @@ const ModuleData* ModuleManager::GetModuleByModuleInMemoryAndAbsoluteAddress(
 
 ModuleData* ModuleManager::GetMutableModuleByModuleInMemoryAndAbsoluteAddress(
     const ModuleInMemory& module_in_memory, uint64_t absolute_address) {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   auto cache_it = absolute_address_to_module_data_cache_.find(absolute_address);
   if (cache_it != absolute_address_to_module_data_cache_.end()) {
     return cache_it->second;
@@ -136,7 +136,7 @@ ModuleData* ModuleManager::GetMutableModuleByModuleInMemoryAndAbsoluteAddress(
 }
 
 const ModuleData* ModuleManager::GetModuleByModuleIdentifier(ModuleIdentifier module_id) const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return GetModuleByModuleIdentifierInternal(module_id);
 }
 
@@ -149,7 +149,7 @@ const ModuleData* ModuleManager::GetModuleByModuleIdentifierInternal(
 }
 
 ModuleData* ModuleManager::GetMutableModuleByModuleIdentifier(ModuleIdentifier module_id) {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return GetMutableModuleByModuleIdentifierInternal(module_id);
 }
 
@@ -162,7 +162,7 @@ ModuleData* ModuleManager::GetMutableModuleByModuleIdentifierInternal(ModuleIden
 
 const ModuleData* ModuleManager::GetModuleByModulePathAndBuildId(
     const ModulePathAndBuildId& module_path_and_build_id) const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   std::optional<orbit_client_data::ModuleIdentifier> module_id =
       module_identifier_provider_->GetModuleIdentifier(module_path_and_build_id);
   if (!module_id.has_value()) return nullptr;
@@ -171,7 +171,7 @@ const ModuleData* ModuleManager::GetModuleByModulePathAndBuildId(
 
 ModuleData* ModuleManager::GetMutableModuleByModulePathAndBuildId(
     const ModulePathAndBuildId& module_path_and_build_id) {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   std::optional<orbit_client_data::ModuleIdentifier> module_id =
       module_identifier_provider_->GetModuleIdentifier(module_path_and_build_id);
   if (!module_id.has_value()) return nullptr;
@@ -179,7 +179,7 @@ ModuleData* ModuleManager::GetMutableModuleByModulePathAndBuildId(
 }
 
 std::vector<const ModuleData*> ModuleManager::GetAllModuleData() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   std::vector<const ModuleData*> result;
   for (const auto& [unused_module_id, module_data] : module_map_) {
     result.push_back(module_data.get());
@@ -189,7 +189,7 @@ std::vector<const ModuleData*> ModuleManager::GetAllModuleData() const {
 
 std::vector<const ModuleData*> ModuleManager::GetModulesByFilename(
     std::string_view filename) const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   std::vector<const ModuleData*> result;
   for (const auto& [module_id, module_data] : module_map_) {
     if (std::filesystem::path(module_data->file_path()).filename().string() == filename) {

--- a/src/ClientData/ProcessData.cpp
+++ b/src/ClientData/ProcessData.cpp
@@ -25,37 +25,37 @@ using orbit_grpc_protos::ModuleInfo;
 namespace orbit_client_data {
 
 uint32_t ProcessData::pid() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return process_info_.pid();
 }
 
 const std::string& ProcessData::name() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return process_info_.name();
 }
 
 double ProcessData::cpu_usage() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return process_info_.cpu_usage();
 }
 
 const std::string& ProcessData::full_path() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return process_info_.full_path();
 }
 
 const std::string& ProcessData::command_line() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return process_info_.command_line();
 }
 
 bool ProcessData::is_64_bit() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return process_info_.is_64_bit();
 }
 
 const std::string& ProcessData::build_id() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return process_info_.build_id();
 }
 
@@ -72,7 +72,7 @@ const std::string& ProcessData::build_id() const {
 }
 
 void ProcessData::UpdateModuleInfos(absl::Span<const ModuleInfo> module_infos) {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   start_address_to_module_in_memory_.clear();
   absolute_address_to_module_in_memory_cache_.clear();
 
@@ -92,7 +92,7 @@ void ProcessData::UpdateModuleInfos(absl::Span<const ModuleInfo> module_infos) {
 }
 
 std::vector<std::string> ProcessData::FindModuleBuildIdsByPath(std::string_view module_path) const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   std::set<std::string> build_ids;
 
   for (const auto& [unused_address, module_in_memory] : start_address_to_module_in_memory_) {
@@ -108,7 +108,7 @@ std::vector<std::string> ProcessData::FindModuleBuildIdsByPath(std::string_view 
 }
 
 void ProcessData::AddOrUpdateModuleInfo(const ModuleInfo& module_info) {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   std::optional<orbit_client_data::ModuleIdentifier> module_id_opt =
       module_identifier_provider_->GetModuleIdentifier(
           {.module_path = module_info.file_path(), .build_id = module_info.build_id()});
@@ -138,7 +138,7 @@ void ProcessData::AddOrUpdateModuleInfo(const ModuleInfo& module_info) {
 }
 
 ErrorMessageOr<ModuleInMemory> ProcessData::FindModuleByAddress(uint64_t absolute_address) const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   if (start_address_to_module_in_memory_.empty()) {
     return ErrorMessage(
         absl::StrFormat("Unable to find module for address %016x: No modules loaded by process %s",
@@ -173,7 +173,7 @@ ErrorMessageOr<ModuleInMemory> ProcessData::FindModuleByAddress(uint64_t absolut
 
 std::vector<uint64_t> ProcessData::GetModuleBaseAddresses(
     orbit_client_data::ModuleIdentifier module_identifier) const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   std::vector<uint64_t> result;
   for (const auto& [start_address, module_in_memory] : start_address_to_module_in_memory_) {
     if (module_in_memory.module_id() == module_identifier) {
@@ -184,7 +184,7 @@ std::vector<uint64_t> ProcessData::GetModuleBaseAddresses(
 }
 
 std::vector<ModuleInMemory> ProcessData::FindModulesByFilename(std::string_view filename) const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   std::vector<ModuleInMemory> result;
   for (const auto& [unused_start_address, module_in_memory] : start_address_to_module_in_memory_) {
     std::optional<std::string> current_module_path =
@@ -199,20 +199,20 @@ std::vector<ModuleInMemory> ProcessData::FindModulesByFilename(std::string_view 
 }
 
 std::map<uint64_t, ModuleInMemory> ProcessData::GetMemoryMapCopy() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return start_address_to_module_in_memory_;
 }
 
 bool ProcessData::IsModuleLoadedByProcess(
     orbit_client_data::ModuleIdentifier module_identifier) const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return std::any_of(
       start_address_to_module_in_memory_.begin(), start_address_to_module_in_memory_.end(),
       [&module_identifier](const auto& it) { return it.second.module_id() == module_identifier; });
 }
 
 std::vector<orbit_client_data::ModuleIdentifier> ProcessData::GetUniqueModuleIdentifiers() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   absl::flat_hash_set<orbit_client_data::ModuleIdentifier> module_ids;
   for (const auto& [unused_address, module_in_memory] : start_address_to_module_in_memory_) {
     module_ids.insert(module_in_memory.module_id());

--- a/src/ClientData/ScopeIdProvider.cpp
+++ b/src/ClientData/ScopeIdProvider.cpp
@@ -96,13 +96,13 @@ std::optional<ScopeId> NameEqualityScopeIdProvider::ProvideId(const TimerInfo& t
   const ScopeInfo scope_info{timer_info.api_scope_name(), scope_type};
 
   {
-    absl::ReaderMutexLock reader_lock{&mutex_};
+    absl::ReaderMutexLock reader_lock{mutex_};
     if (std::optional<ScopeId> id = GetExistingScopeId(scope_info); id.has_value()) {
       return id.value();
     }
   }
 
-  absl::WriterMutexLock writer_local{&mutex_};
+  absl::WriterMutexLock writer_local{mutex_};
 
   if (std::optional<ScopeId> id = GetExistingScopeId(scope_info); id.has_value()) {
     return id.value();
@@ -116,7 +116,7 @@ std::optional<ScopeId> NameEqualityScopeIdProvider::ProvideId(const TimerInfo& t
 }
 
 [[nodiscard]] std::vector<ScopeId> NameEqualityScopeIdProvider::GetAllProvidedScopeIds() const {
-  absl::ReaderMutexLock reader_lock{&mutex_};
+  absl::ReaderMutexLock reader_lock{mutex_};
   std::vector<ScopeId> ids;
   std::transform(std::begin(scope_id_to_info_), std::end(scope_id_to_info_),
                  std::back_inserter(ids), [](const auto& entry) { return entry.first; });
@@ -124,7 +124,7 @@ std::optional<ScopeId> NameEqualityScopeIdProvider::ProvideId(const TimerInfo& t
 }
 
 const ScopeInfo& NameEqualityScopeIdProvider::GetScopeInfo(ScopeId scope_id) const {
-  absl::ReaderMutexLock reader_lock{&mutex_};
+  absl::ReaderMutexLock reader_lock{mutex_};
   const auto it = scope_id_to_info_.find(scope_id);
   ORBIT_CHECK(it != scope_id_to_info_.end());
   return it->second;

--- a/src/ClientData/ScopeTreeTimerData.cpp
+++ b/src/ClientData/ScopeTreeTimerData.cpp
@@ -21,7 +21,7 @@ const orbit_client_protos::TimerInfo& ScopeTreeTimerData::AddTimer(
   const auto& timer_info_ref = timer_data_.AddTimer(std::move(timer_info), /*unused_depth=*/0);
 
   if (scope_tree_update_type_ == ScopeTreeUpdateType::kAlways) {
-    absl::MutexLock lock(&scope_tree_mutex_);
+    absl::MutexLock lock(scope_tree_mutex_);
     scope_tree_.Insert(&timer_info_ref);
   }
   return timer_info_ref;
@@ -34,7 +34,7 @@ void ScopeTreeTimerData::OnCaptureComplete() {
   std::vector<const TimerChain*> timer_chains = timer_data_.GetChains();
   for (const TimerChain* timer_chain : timer_chains) {
     ORBIT_CHECK(timer_chain != nullptr);
-    absl::MutexLock lock(&scope_tree_mutex_);
+    absl::MutexLock lock(scope_tree_mutex_);
     for (const auto& block : *timer_chain) {
       for (size_t k = 0; k < block.size(); ++k) {
         scope_tree_.Insert(&block[k]);
@@ -65,7 +65,7 @@ std::vector<const orbit_client_protos::TimerInfo*> ScopeTreeTimerData::GetTimers
     uint32_t depth, uint64_t start_ns, uint64_t end_ns) const {
   ORBIT_SCOPE_WITH_COLOR("GetTimersAtDepthExclusive", kOrbitColorGreen);
   std::vector<const orbit_client_protos::TimerInfo*> all_timers_at_depth;
-  absl::MutexLock lock(&scope_tree_mutex_);
+  absl::MutexLock lock(scope_tree_mutex_);
 
   const auto& ordered_nodes = scope_tree_.GetOrderedNodesAtDepth(depth);
   if (ordered_nodes.empty()) return all_timers_at_depth;
@@ -85,7 +85,7 @@ std::vector<const orbit_client_protos::TimerInfo*> ScopeTreeTimerData::GetTimers
 std::vector<const orbit_client_protos::TimerInfo*> ScopeTreeTimerData::GetTimersAtDepth(
     uint32_t depth, uint64_t start_ns, uint64_t end_ns) const {
   std::vector<const orbit_client_protos::TimerInfo*> all_timers_at_depth;
-  absl::MutexLock lock(&scope_tree_mutex_);
+  absl::MutexLock lock(scope_tree_mutex_);
 
   const auto& ordered_nodes = scope_tree_.GetOrderedNodesAtDepth(depth);
   if (ordered_nodes.empty()) return all_timers_at_depth;
@@ -107,7 +107,7 @@ std::vector<const orbit_client_protos::TimerInfo*> ScopeTreeTimerData::GetTimers
     uint32_t depth, uint32_t resolution, uint64_t start_ns, uint64_t end_ns) const {
   ORBIT_SCOPE_WITH_COLOR("GetTimersAtDepthDiscretized", kOrbitColorAmber);
   if (resolution == 0) return {};
-  absl::MutexLock lock(&scope_tree_mutex_);
+  absl::MutexLock lock(scope_tree_mutex_);
   // The query is for the interval [start_ns, end_ns], but it's easier to work with the close-open
   // interval [start_ns, end_ns+1). We have to be careful with overflowing.
   end_ns = std::max(end_ns, end_ns + 1);
@@ -130,25 +130,25 @@ std::vector<const orbit_client_protos::TimerInfo*> ScopeTreeTimerData::GetTimers
 
 const orbit_client_protos::TimerInfo* ScopeTreeTimerData::GetLeft(
     const orbit_client_protos::TimerInfo& timer) const {
-  absl::MutexLock lock(&scope_tree_mutex_);
+  absl::MutexLock lock(scope_tree_mutex_);
   return scope_tree_.FindPreviousScopeAtDepth(timer);
 }
 
 const orbit_client_protos::TimerInfo* ScopeTreeTimerData::GetRight(
     const orbit_client_protos::TimerInfo& timer) const {
-  absl::MutexLock lock(&scope_tree_mutex_);
+  absl::MutexLock lock(scope_tree_mutex_);
   return scope_tree_.FindNextScopeAtDepth(timer);
 }
 
 const orbit_client_protos::TimerInfo* ScopeTreeTimerData::GetUp(
     const orbit_client_protos::TimerInfo& timer) const {
-  absl::MutexLock lock(&scope_tree_mutex_);
+  absl::MutexLock lock(scope_tree_mutex_);
   return scope_tree_.FindParent(timer);
 }
 
 const orbit_client_protos::TimerInfo* ScopeTreeTimerData::GetDown(
     const orbit_client_protos::TimerInfo& timer) const {
-  absl::MutexLock lock(&scope_tree_mutex_);
+  absl::MutexLock lock(scope_tree_mutex_);
   return scope_tree_.FindFirstChild(timer);
 }
 

--- a/src/ClientData/TimerData.cpp
+++ b/src/ClientData/TimerData.cpp
@@ -32,7 +32,7 @@ const TimerInfo& TimerData::AddTimer(TimerInfo timer_info, uint32_t depth) {
 
 std::vector<const TimerChain*> TimerData::GetChains() const {
   std::vector<const TimerChain*> chains;
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   for (const auto& it : timers_) {
     chains.push_back(it.second.get());
   }
@@ -41,7 +41,7 @@ std::vector<const TimerChain*> TimerData::GetChains() const {
 }
 
 const TimerChain* TimerData::GetChain(uint64_t depth) const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   auto it = timers_.find(depth);
   if (it != timers_.end()) {
     return it->second.get();
@@ -55,7 +55,7 @@ std::vector<const orbit_client_protos::TimerInfo*> TimerData::GetTimers(uint64_t
                                                                         bool exclusive) const {
   ORBIT_SCOPE_WITH_COLOR("GetTimersAtDepthDiscretized", kOrbitColorBlueGrey);
   // TODO(b/204173236): use it in TimerTracks.
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   std::vector<const orbit_client_protos::TimerInfo*> timers;
   for (const auto& [depth, chain] : timers_) {
     ORBIT_CHECK(chain != nullptr);
@@ -78,7 +78,7 @@ std::vector<const orbit_client_protos::TimerInfo*> TimerData::GetTimers(uint64_t
 std::vector<const orbit_client_protos::TimerInfo*> TimerData::GetTimersAtDepthDiscretized(
     uint32_t depth, uint32_t resolution, uint64_t start_ns, uint64_t end_ns) const {
   ORBIT_SCOPE_WITH_COLOR("GetTimersAtDepthDiscretized", kOrbitColorBlueGrey);
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   // The query is for the interval [start_ns, end_ns], but it's easier to work with the close-open
   // interval [start_ns, end_ns+1). We have to be careful with overflowing if end_ns is the maximum
   // unsigned value. In that case, we will just ignore this max_timestamp for simplicity.
@@ -157,7 +157,7 @@ void TimerData::UpdateMaxTime(uint64_t max_time) {
 }
 
 TimerChain* TimerData::GetOrCreateTimerChain(uint64_t depth) {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   auto it = timers_.find(depth);
   if (it != timers_.end()) {
     return it->second.get();

--- a/src/ClientData/TimerTrackDataIdManager.cpp
+++ b/src/ClientData/TimerTrackDataIdManager.cpp
@@ -42,7 +42,7 @@ uint32_t TimerTrackDataIdManager::GenerateTrackIdFromTimerInfo(const TimerInfo& 
 }
 
 uint32_t TimerTrackDataIdManager::GenerateFrameTrackId(uint64_t function_id) {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   auto [it, inserted] = frame_track_ids_.try_emplace(function_id, next_track_id_);
   if (inserted) {
     next_track_id_++;
@@ -51,7 +51,7 @@ uint32_t TimerTrackDataIdManager::GenerateFrameTrackId(uint64_t function_id) {
 }
 
 uint32_t TimerTrackDataIdManager::GenerateGpuTrackId(uint64_t timeline_hash) {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   auto [it, inserted] = gpu_track_ids_.try_emplace(timeline_hash, next_track_id_);
   if (inserted) {
     next_track_id_++;
@@ -60,7 +60,7 @@ uint32_t TimerTrackDataIdManager::GenerateGpuTrackId(uint64_t timeline_hash) {
 }
 
 uint32_t TimerTrackDataIdManager::GenerateAsyncTrackId(std::string_view name) {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   auto [it, inserted] = async_track_ids_.try_emplace(name, next_track_id_);
   if (inserted) {
     next_track_id_++;
@@ -69,7 +69,7 @@ uint32_t TimerTrackDataIdManager::GenerateAsyncTrackId(std::string_view name) {
 }
 
 uint32_t TimerTrackDataIdManager::GenerateThreadTrackId(uint32_t thread_id) {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   auto [it, inserted] = thread_track_ids_.try_emplace(thread_id, next_track_id_);
   if (inserted) {
     next_track_id_++;

--- a/src/ClientData/TracepointData.cpp
+++ b/src/ClientData/TracepointData.cpp
@@ -16,7 +16,7 @@ namespace orbit_client_data {
 void TracepointData::EmplaceTracepointEvent(uint64_t timestamp_ns, uint64_t tracepoint_id,
                                             uint32_t process_id, uint32_t thread_id, int32_t cpu,
                                             bool is_same_pid_as_target) {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   num_total_tracepoint_events_++;
 
   TracepointEventInfo event(process_id, thread_id, cpu, timestamp_ns, tracepoint_id);
@@ -37,7 +37,7 @@ void TracepointData::EmplaceTracepointEvent(uint64_t timestamp_ns, uint64_t trac
 
 void TracepointData::ForEachTracepointEvent(
     const std::function<void(const TracepointEventInfo&)>& action) const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   for (auto const& entry : thread_id_to_time_to_tracepoint_) {
     for (auto const& time_to_tracepoint_event : entry.second) {
       action(time_to_tracepoint_event.second);
@@ -62,7 +62,7 @@ void ForEachTracepointEventInRange(
 void TracepointData::ForEachTracepointEventOfThreadInTimeRange(
     uint32_t thread_id, uint64_t min_tick, uint64_t max_tick_exclusive,
     const std::function<void(const TracepointEventInfo&)>& action) const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   if (thread_id == orbit_base::kAllThreadsOfAllProcessesTid) {
     for (const auto& [unused_thread_id, time_to_tracepoint] : thread_id_to_time_to_tracepoint_) {
       ForEachTracepointEventInRange(min_tick, max_tick_exclusive, time_to_tracepoint, action);
@@ -84,7 +84,7 @@ void TracepointData::ForEachTracepointEventOfThreadInTimeRange(
 }
 
 uint32_t TracepointData::GetNumTracepointEventsForThreadId(uint32_t thread_id) const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   if (thread_id == orbit_base::kAllThreadsOfAllProcessesTid) {
     return num_total_tracepoint_events_;
   }
@@ -105,14 +105,14 @@ uint32_t TracepointData::GetNumTracepointEventsForThreadId(uint32_t thread_id) c
 }
 
 bool TracepointData::AddUniqueTracepointInfo(uint64_t key, TracepointInfo tracepoint) {
-  absl::MutexLock lock{&unique_tracepoints_mutex_};
+  absl::MutexLock lock{unique_tracepoints_mutex_};
   auto [unused_it, inserted] =
       unique_tracepoints_.try_emplace(key, std::make_unique<TracepointInfo>(std::move(tracepoint)));
   return inserted;
 }
 
 const TracepointInfo* TracepointData::GetTracepointInfo(uint64_t tracepoint_id) const {
-  absl::MutexLock lock{&unique_tracepoints_mutex_};
+  absl::MutexLock lock{unique_tracepoints_mutex_};
   auto it = unique_tracepoints_.find(tracepoint_id);
   if (it != unique_tracepoints_.end()) {
     return it->second.get();
@@ -121,13 +121,13 @@ const TracepointInfo* TracepointData::GetTracepointInfo(uint64_t tracepoint_id) 
 }
 
 bool TracepointData::HasTracepointId(uint64_t tracepoint_id) const {
-  absl::MutexLock lock{&unique_tracepoints_mutex_};
+  absl::MutexLock lock{unique_tracepoints_mutex_};
   return unique_tracepoints_.contains(tracepoint_id);
 }
 
 void TracepointData::ForEachUniqueTracepointInfo(
     const std::function<void(const TracepointInfo&)>& action) const {
-  absl::MutexLock lock(&unique_tracepoints_mutex_);
+  absl::MutexLock lock(unique_tracepoints_mutex_);
   for (const auto& it : unique_tracepoints_) {
     ORBIT_CHECK(it.second != nullptr);
     action(*it.second);

--- a/src/ClientData/include/ClientData/CaptureData.h
+++ b/src/ClientData/include/ClientData/CaptureData.h
@@ -123,12 +123,12 @@ class CaptureData {
   }
 
   [[nodiscard]] bool HasThreadStatesForThread(uint32_t tid) const {
-    absl::MutexLock lock{&thread_state_slices_mutex_};
+    absl::MutexLock lock{thread_state_slices_mutex_};
     return thread_state_slices_.count(tid) > 0;
   }
 
   void AddThreadStateSlice(ThreadStateSliceInfo state_slice) {
-    absl::MutexLock lock{&thread_state_slices_mutex_};
+    absl::MutexLock lock{thread_state_slices_mutex_};
     thread_state_slices_[state_slice.tid()].emplace_back(state_slice);
   }
 

--- a/src/ClientData/include/ClientData/ScopeIdProvider.h
+++ b/src/ClientData/include/ClientData/ScopeIdProvider.h
@@ -68,7 +68,7 @@ class NameEqualityScopeIdProvider : public ScopeIdProvider {
   [[nodiscard]] uint64_t ScopeIdToFunctionId(ScopeId scope_id) const override;
 
   [[nodiscard]] ScopeId GetMaxId() const override {
-    absl::ReaderMutexLock reader_lock{&mutex_};
+    absl::ReaderMutexLock reader_lock{mutex_};
     return ScopeId(*next_id_ - 1);
   }
 

--- a/src/ClientData/include/ClientData/ScopeTreeTimerData.h
+++ b/src/ClientData/include/ClientData/ScopeTreeTimerData.h
@@ -56,13 +56,13 @@ class ScopeTreeTimerData final : public TimerDataInterface {
   [[nodiscard]] bool IsEmpty() const override { return GetNumberOfTimers() == 0; };
   // Special case. ScopeTree has a root node in depth 0 which shouldn't be considered.
   [[nodiscard]] size_t GetNumberOfTimers() const override {
-    absl::MutexLock lock(&scope_tree_mutex_);
+    absl::MutexLock lock(scope_tree_mutex_);
     return scope_tree_.Size() - 1;
   }
   [[nodiscard]] uint64_t GetMinTime() const override { return timer_data_.GetMinTime(); }
   [[nodiscard]] uint64_t GetMaxTime() const override { return timer_data_.GetMaxTime(); }
   [[nodiscard]] uint32_t GetDepth() const override {
-    absl::MutexLock lock(&scope_tree_mutex_);
+    absl::MutexLock lock(scope_tree_mutex_);
     return scope_tree_.Depth();
   }
   [[nodiscard]] uint32_t GetProcessId() const override { return timer_data_.GetProcessId(); }

--- a/src/ClientData/include/ClientData/ThreadTrackDataManager.h
+++ b/src/ClientData/include/ClientData/ThreadTrackDataManager.h
@@ -26,7 +26,7 @@ class ThreadTrackDataManager final {
                                     : ScopeTreeTimerData::ScopeTreeUpdateType::kAlways){};
 
   const orbit_client_protos::TimerInfo& AddTimer(orbit_client_protos::TimerInfo timer_info) {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     uint32_t thread_id = timer_info.thread_id();
     // Get or create ScopeTreeTimerData optimized to only make one query to the map, as AddTimer
     // will be executed many times.
@@ -38,7 +38,7 @@ class ThreadTrackDataManager final {
   }
 
   const ScopeTreeTimerData* GetScopeTreeTimerData(uint32_t thread_id) const {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     auto it = scope_tree_timer_data_map_.find(thread_id);
     if (it == scope_tree_timer_data_map_.end()) {
       return nullptr;
@@ -48,14 +48,14 @@ class ThreadTrackDataManager final {
 
   // This function should be used only for Tracks that needs to be there before a Timer appears.
   const ScopeTreeTimerData* CreateScopeTreeTimerData(uint32_t thread_id) {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     auto [it, unused_inserted] = scope_tree_timer_data_map_.try_emplace(
         thread_id, std::make_unique<ScopeTreeTimerData>(thread_id, scope_tree_update_type_));
     return it->second.get();
   };
 
   [[nodiscard]] std::vector<ScopeTreeTimerData*> GetAllScopeTreeTimerData() const {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     std::vector<ScopeTreeTimerData*> all_scope_tree_timer_data;
     all_scope_tree_timer_data.reserve(scope_tree_timer_data_map_.size());
     for (const auto& [unused_tid, scope_tree_timer_data] : scope_tree_timer_data_map_) {

--- a/src/ClientData/include/ClientData/TimerDataManager.h
+++ b/src/ClientData/include/ClientData/TimerDataManager.h
@@ -21,7 +21,7 @@ class TimerDataManager final {
   TimerDataManager() = default;
 
   [[nodiscard]] std::pair<uint64_t, TimerData*> CreateTimerData() {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     uint64_t id = timer_data_.size();
     timer_data_.emplace_back(std::make_unique<TimerData>());
     return std::make_pair(id, timer_data_.at(id).get());
@@ -32,7 +32,7 @@ class TimerDataManager final {
       uint64_t min_tick = std::numeric_limits<uint64_t>::min(),
       uint64_t max_tick = std::numeric_limits<uint64_t>::max(), bool exclusive = false) const {
     std::vector<const orbit_client_protos::TimerInfo*> timers;
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     for (const std::unique_ptr<TimerData>& timer_datum : timer_data_) {
       for (const orbit_client_protos::TimerInfo* timer :
            timer_datum->GetTimers(min_tick, max_tick, exclusive)) {

--- a/src/ClientServices/ProcessManager.cpp
+++ b/src/ClientServices/ProcessManager.cpp
@@ -71,7 +71,7 @@ ProcessManagerImpl::ProcessManagerImpl(const std::shared_ptr<grpc::Channel>& cha
 
 void ProcessManagerImpl::SetProcessListUpdateListener(
     const std::function<void(std::vector<orbit_grpc_protos::ProcessInfo>)>& listener) {
-  absl::MutexLock lock(&process_list_update_listener_mutex_);
+  absl::MutexLock lock(process_list_update_listener_mutex_);
   process_list_update_listener_ = listener;
 }
 
@@ -90,9 +90,9 @@ void ProcessManagerImpl::Start() {
 }
 
 void ProcessManagerImpl::ShutdownAndWait() {
-  shutdown_mutex_.Lock();
+  shutdown_mutex_.lock();
   shutdown_initiated_ = true;
-  shutdown_mutex_.Unlock();
+  shutdown_mutex_.unlock();
   if (worker_thread_.joinable()) {
     worker_thread_.join();
   }
@@ -105,10 +105,10 @@ void ProcessManagerImpl::WorkerFunction() {
     if (shutdown_mutex_.LockWhenWithTimeout(absl::Condition(IsTrue, &shutdown_initiated_),
                                             refresh_timeout_)) {
       // Shutdown was initiated we need to exit
-      shutdown_mutex_.Unlock();
+      shutdown_mutex_.unlock();
       return;
     }
-    shutdown_mutex_.Unlock();
+    shutdown_mutex_.unlock();
     // Timeout expired - refresh the list
 
     ErrorMessageOr<std::vector<ProcessInfo>> result = process_client_->GetProcessList();
@@ -120,7 +120,7 @@ void ProcessManagerImpl::WorkerFunction() {
     std::function<void(std::vector<orbit_grpc_protos::ProcessInfo>)>
         process_list_update_listener_copy;
     {
-      absl::MutexLock callback_lock(&process_list_update_listener_mutex_);
+      absl::MutexLock callback_lock(process_list_update_listener_mutex_);
       process_list_update_listener_copy = process_list_update_listener_;
     }
     if (process_list_update_listener_copy) {

--- a/src/ClientServices/WindowsProcessLauncherClient.cpp
+++ b/src/ClientServices/WindowsProcessLauncherClient.cpp
@@ -93,7 +93,7 @@ ErrorMessageOr<orbit_grpc_protos::ProcessInfo> WindowsProcessLauncherClientImpl:
                                 ? LaunchedProcess::State::kSpinningAtEntryPoint
                                 : LaunchedProcess::State::kExecutingOrExited;
   {
-    absl::MutexLock lock(&launched_processes_by_pid_mutex_);
+    absl::MutexLock lock(launched_processes_by_pid_mutex_);
     launched_processes_by_pid_.emplace(process_info.pid(), launched_process);
   }
 
@@ -146,20 +146,20 @@ ErrorMessageOr<void> WindowsProcessLauncherClientImpl::ResumeProcessSuspendedAtE
 
 void WindowsProcessLauncherClientImpl::UpdateLaunchedProcessState(
     uint32_t pid, LaunchedProcess::State new_state) {
-  absl::MutexLock lock(&launched_processes_by_pid_mutex_);
+  absl::MutexLock lock(launched_processes_by_pid_mutex_);
   LaunchedProcess& launched_process = launched_processes_by_pid_.at(pid);
   launched_process.state_ = new_state;
 }
 
 bool WindowsProcessLauncherClientImpl::IsProcessSpinningAtEntryPoint(uint32_t pid) {
-  absl::MutexLock lock(&launched_processes_by_pid_mutex_);
+  absl::MutexLock lock(launched_processes_by_pid_mutex_);
   auto launched_process_it = launched_processes_by_pid_.find(pid);
   if (launched_process_it == launched_processes_by_pid_.end()) return false;
   return launched_process_it->second.state_ == LaunchedProcess::State::kSpinningAtEntryPoint;
 }
 
 bool WindowsProcessLauncherClientImpl::IsProcessSuspendedAtEntryPoint(uint32_t pid) {
-  absl::MutexLock lock(&launched_processes_by_pid_mutex_);
+  absl::MutexLock lock(launched_processes_by_pid_mutex_);
   auto launched_process_it = launched_processes_by_pid_.find(pid);
   if (launched_process_it == launched_processes_by_pid_.end()) return false;
   return launched_process_it->second.state_ == LaunchedProcess::State::kSuspendedAtEntryPoint;

--- a/src/DataViews/LiveFunctionsDataViewTest.cpp
+++ b/src/DataViews/LiveFunctionsDataViewTest.cpp
@@ -89,7 +89,6 @@ using orbit_data_views::kMenuActionUnselect;
 using orbit_grpc_protos::InstrumentedFunction;
 using orbit_grpc_protos::ModuleInfo;
 
-using ::testing::Invoke;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
@@ -901,9 +900,9 @@ TEST_F(LiveFunctionsDataViewTest, OnRefreshWithNoIndicesResetsHistogram) {
 }
 
 TEST_F(LiveFunctionsDataViewTest, HistogramIsProperlyUpdated) {
-  EXPECT_CALL(app_, ProvideScopeId).WillRepeatedly(Invoke([&](const TimerInfo& timer) {
+  EXPECT_CALL(app_, ProvideScopeId).WillRepeatedly([&](const TimerInfo& timer) {
     return timer.function_id();
-  }));
+  });
 
   AddFunctionsByIndices({0});
 

--- a/src/DataViews/PresetsDataViewTest.cpp
+++ b/src/DataViews/PresetsDataViewTest.cpp
@@ -69,9 +69,9 @@ TEST_F(PresetsDataViewTest, Empty) {
 TEST_F(PresetsDataViewTest, CheckLabelAndColorForLoadStates) {
   // GetPresetLoadState is called once per `GetValue`, `GetToolTip` and `GetDisplayColor` call.
   auto load_state = PresetLoadState::kLoadable;
-  EXPECT_CALL(app_, GetPresetLoadState).Times(13).WillRepeatedly(testing::Invoke([&load_state]() {
+  EXPECT_CALL(app_, GetPresetLoadState).Times(13).WillRepeatedly([&load_state]() {
     return PresetLoadState(load_state);
-  }));
+  });
 
   orbit_client_protos::PresetInfo preset_info0{};
   orbit_preset_file::PresetFile preset_file0{std::filesystem::path{}, preset_info0};

--- a/src/DataViews/SamplingReportDataViewTest.cpp
+++ b/src/DataViews/SamplingReportDataViewTest.cpp
@@ -387,12 +387,12 @@ class SamplingReportDataViewTest : public testing::Test {
         .WillRepeatedly(ReturnRef(confidence_interval_estimator_));
 
     EXPECT_CALL(confidence_interval_estimator_, Estimate)
-        .WillRepeatedly(testing::Invoke([](float ratio, uint32_t /*trials*/) {
+        .WillRepeatedly([](float ratio, uint32_t /*trials*/) {
           orbit_statistics::BinomialConfidenceInterval confidence_interval{
               ratio - kConfidenceIntervalLeftSectionLength,
               ratio + kConfidenceIntervalRightSectionLength};
           return confidence_interval;
-        }));
+        });
 
     view_.Init();
     for (size_t i = 0; i < kNumFunctions; i++) {

--- a/src/FakeProducerSideService/include/FakeProducerSideService/FakeProducerSideService.h
+++ b/src/FakeProducerSideService/include/FakeProducerSideService/FakeProducerSideService.h
@@ -29,7 +29,7 @@ class FakeProducerSideService : public orbit_grpc_protos::ProducerSideService::S
       return grpc::Status::CANCELLED;
     }
     {
-      absl::WriterMutexLock lock{&context_and_stream_mutex_};
+      absl::WriterMutexLock lock{context_and_stream_mutex_};
       EXPECT_EQ(context_, nullptr);
       EXPECT_EQ(stream_, nullptr);
       context_ = context;
@@ -39,7 +39,7 @@ class FakeProducerSideService : public orbit_grpc_protos::ProducerSideService::S
     while (true) {
       orbit_grpc_protos::ReceiveCommandsAndSendEventsRequest request;
       {
-        absl::ReaderMutexLock lock{&context_and_stream_mutex_};
+        absl::ReaderMutexLock lock{context_and_stream_mutex_};
         if (!stream->Read(&request)) break;
       }
       EXPECT_NE(request.event_case(),
@@ -60,7 +60,7 @@ class FakeProducerSideService : public orbit_grpc_protos::ProducerSideService::S
     }
 
     {
-      absl::WriterMutexLock lock{&context_and_stream_mutex_};
+      absl::WriterMutexLock lock{context_and_stream_mutex_};
       context_ = nullptr;
       stream_ = nullptr;
     }
@@ -68,7 +68,7 @@ class FakeProducerSideService : public orbit_grpc_protos::ProducerSideService::S
   }
 
   void SendStartCaptureCommand(orbit_grpc_protos::CaptureOptions capture_options) {
-    absl::ReaderMutexLock lock{&context_and_stream_mutex_};
+    absl::ReaderMutexLock lock{context_and_stream_mutex_};
     ASSERT_NE(stream_, nullptr);
     orbit_grpc_protos::ReceiveCommandsAndSendEventsResponse command;
     *command.mutable_start_capture_command()->mutable_capture_options() =
@@ -78,7 +78,7 @@ class FakeProducerSideService : public orbit_grpc_protos::ProducerSideService::S
   }
 
   void SendStopCaptureCommand() {
-    absl::ReaderMutexLock lock{&context_and_stream_mutex_};
+    absl::ReaderMutexLock lock{context_and_stream_mutex_};
     ASSERT_NE(stream_, nullptr);
     orbit_grpc_protos::ReceiveCommandsAndSendEventsResponse command;
     command.mutable_stop_capture_command();
@@ -87,7 +87,7 @@ class FakeProducerSideService : public orbit_grpc_protos::ProducerSideService::S
   }
 
   void SendCaptureFinishedCommand() {
-    absl::ReaderMutexLock lock{&context_and_stream_mutex_};
+    absl::ReaderMutexLock lock{context_and_stream_mutex_};
     ASSERT_NE(stream_, nullptr);
     orbit_grpc_protos::ReceiveCommandsAndSendEventsResponse command;
     command.mutable_capture_finished_command();
@@ -98,14 +98,14 @@ class FakeProducerSideService : public orbit_grpc_protos::ProducerSideService::S
   void FinishAndDisallowRpc() {
     rpc_allowed_ = false;
     {
-      absl::ReaderMutexLock lock{&context_and_stream_mutex_};
+      absl::ReaderMutexLock lock{context_and_stream_mutex_};
       if (context_ != nullptr) {
         EXPECT_NE(stream_, nullptr);
         context_->TryCancel();
       }
     }
     {
-      absl::WriterMutexLock lock{&context_and_stream_mutex_};
+      absl::WriterMutexLock lock{context_and_stream_mutex_};
       context_ = nullptr;
       stream_ = nullptr;
     }

--- a/src/GrpcProtos/services.proto
+++ b/src/GrpcProtos/services.proto
@@ -7,7 +7,6 @@ syntax = "proto3";
 package orbit_grpc_protos;
 
 import "capture.proto";
-import "code_block.proto";
 import "module.proto";
 import "process.proto";
 import "tracepoint.proto";

--- a/src/Introspection/Introspection.cpp
+++ b/src/Introspection/Introspection.cpp
@@ -47,7 +47,7 @@ IntrospectionListener::IntrospectionListener(IntrospectionEventCallback callback
       orbit_base::ThreadPool::Create(kMinNumThreads, kMaxNumThreads, absl::Milliseconds(500));
 
   // Activate listener (only one listener instance is supported).
-  absl::MutexLock lock(&global_introspection_mutex);
+  absl::MutexLock lock(global_introspection_mutex);
   ORBIT_CHECK(!IsActive());
   InitializeIntrospection();
   global_introspection_listener = this;
@@ -61,7 +61,7 @@ IntrospectionListener::~IntrospectionListener() {
   // Note that this is required, as otherwise, we might allow scheduling
   // new events on the already shut down thread pool.
   {
-    absl::MutexLock lock(&global_introspection_mutex);
+    absl::MutexLock lock(global_introspection_mutex);
     ORBIT_CHECK(IsActive());
     shutdown_initiated_ = true;
   }
@@ -70,7 +70,7 @@ IntrospectionListener::~IntrospectionListener() {
   thread_pool_->Wait();
 
   // Deactivate and destroy the listener.
-  absl::MutexLock lock(&global_introspection_mutex);
+  absl::MutexLock lock(global_introspection_mutex);
   active_ = false;
   global_introspection_listener = nullptr;
 }
@@ -92,11 +92,11 @@ void IntrospectionListener::DeferApiEventProcessing(const orbit_api::ApiEventVar
   if (is_internal_update) return;
 
   // User callback is called from a worker thread to minimize contention on instrumented threads.
-  absl::MutexLock lock(&global_introspection_mutex);
+  absl::MutexLock lock(global_introspection_mutex);
   if (IsShutdownInitiated()) return;
   global_introspection_listener->thread_pool_->Schedule([api_event]() {
     ScopeToggle scope_toggle(&is_internal_update, true);
-    absl::MutexLock lock(&global_introspection_mutex);
+    absl::MutexLock lock(global_introspection_mutex);
     if (!IsActive()) return;
     global_introspection_listener->user_callback_(api_event);
   });

--- a/src/LinuxCaptureService/LinuxCaptureServiceBase.cpp
+++ b/src/LinuxCaptureService/LinuxCaptureServiceBase.cpp
@@ -265,7 +265,7 @@ LinuxCaptureServiceBase::WaitForStopCaptureRequestOrMemoryThresholdExceeded(
         StopCaptureReason external_stop_reason =
             stop_capture_request_waiter->WaitForStopCaptureRequest();
 
-        absl::MutexLock lock{stop_capture_mutex.get()};
+        absl::MutexLock lock{*stop_capture_mutex};
         if (!*stop_capture) {
           ORBIT_LOG("Client finished writing on Capture's gRPC stream: stopping capture");
           *stop_capture = true;
@@ -283,7 +283,7 @@ LinuxCaptureServiceBase::WaitForStopCaptureRequestOrMemoryThresholdExceeded(
             kWatchdogThresholdBytes, kMemTotalBytes);
   while (true) {
     {
-      absl::MutexLock lock{stop_capture_mutex.get()};
+      absl::MutexLock lock{*stop_capture_mutex};
       static constexpr absl::Duration kWatchdogPollInterval = absl::Seconds(1);
       if (stop_capture_mutex->AwaitWithTimeout(absl::Condition(stop_capture.get()),
                                                kWatchdogPollInterval)) {
@@ -300,7 +300,7 @@ LinuxCaptureServiceBase::WaitForStopCaptureRequestOrMemoryThresholdExceeded(
     }
     if (rss_bytes.value() > kWatchdogThresholdBytes) {
       ORBIT_LOG("Memory threshold exceeded: stopping capture (and stopping memory watchdog)");
-      absl::MutexLock lock{stop_capture_mutex.get()};
+      absl::MutexLock lock{*stop_capture_mutex};
       *stop_capture = true;
       *stop_capture_reason = StopCaptureReason::kMemoryWatchdog;
       break;
@@ -310,7 +310,7 @@ LinuxCaptureServiceBase::WaitForStopCaptureRequestOrMemoryThresholdExceeded(
   // The memory watchdog loop exits when either the stop capture is requested, or the
   // memory threshold was exceeded. So at that point we can proceed with stopping the capture.
   {
-    absl::MutexLock lock{stop_capture_mutex.get()};
+    absl::MutexLock lock{*stop_capture_mutex};
     ORBIT_CHECK(stop_capture_reason->has_value());
     return stop_capture_reason->value();
   }

--- a/src/LinuxTracing/LinuxTracingUtilsTest.cpp
+++ b/src/LinuxTracing/LinuxTracingUtilsTest.cpp
@@ -42,13 +42,13 @@ TEST(GetThreadState, LinuxTracingTestsMainAndAnother) {
   std::optional<char> thread_state_holding_mutex;
   std::optional<char> main_state_waiting_mutex;
 
-  mutex.Lock();
+  mutex.lock();
   std::thread thread{[&] {
     // Make sure /proc/<pid>/stat is parsed correctly
     // even when the thread name contains spaces and parentheses.
     orbit_base::SetCurrentThreadName(") )  )()( )(  )");
     {
-      absl::MutexLock lock{&mutex};
+      absl::MutexLock lock{mutex};
       thread_tid = syscall(SYS_gettid);
       thread_state_holding_mutex = GetThreadState(thread_tid);
       main_state_waiting_mutex = GetThreadState(main_tid);
@@ -59,7 +59,7 @@ TEST(GetThreadState, LinuxTracingTestsMainAndAnother) {
   }};
 
   mutex.Await(absl::Condition(+[](pid_t* tid) { return *tid != -1; }, &thread_tid));
-  mutex.Unlock();
+  mutex.unlock();
 
   ASSERT_TRUE(thread_state_holding_mutex.has_value());
   EXPECT_EQ('R', thread_state_holding_mutex.value());

--- a/src/LinuxTracing/TracerImpl.cpp
+++ b/src/LinuxTracing/TracerImpl.cpp
@@ -1608,7 +1608,7 @@ uint64_t TracerImpl::ProcessThrottleUnthrottleEventAndReturnTimestamp(
 }
 
 void TracerImpl::DeferEvent(PerfEvent&& event) {
-  absl::MutexLock lock{&deferred_events_being_buffered_mutex_};
+  absl::MutexLock lock{deferred_events_being_buffered_mutex_};
   deferred_events_being_buffered_.emplace_back(std::move(event));
 }
 
@@ -1622,7 +1622,7 @@ void TracerImpl::ProcessDeferredEvents() {
     should_exit = stop_deferred_thread_;
 
     {
-      absl::MutexLock lock{&deferred_events_being_buffered_mutex_};
+      absl::MutexLock lock{deferred_events_being_buffered_mutex_};
       deferred_events_being_buffered_.swap(deferred_events_to_process_);
     }
 
@@ -1702,7 +1702,7 @@ void TracerImpl::Reset() {
 
   stop_deferred_thread_ = false;
   {
-    absl::MutexLock lock{&deferred_events_being_buffered_mutex_};
+    absl::MutexLock lock{deferred_events_being_buffered_mutex_};
     deferred_events_being_buffered_.clear();
   }
   deferred_events_to_process_.clear();

--- a/src/LinuxTracing/UprobesUnwindingVisitorCallchainTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorCallchainTest.cpp
@@ -35,7 +35,6 @@ using ::testing::_;
 using ::testing::AllOf;
 using ::testing::ElementsAre;
 using ::testing::Ge;
-using ::testing::Invoke;
 using ::testing::Lt;
 using ::testing::Return;
 using ::testing::SaveArg;
@@ -405,9 +404,7 @@ TEST_F(UprobesUnwindingVisitorCallchainTest, VisitPatchableCallchainSampleSendsC
     callchain[2] = kTargetAddress2 + 1;
     return true;
   };
-  EXPECT_CALL(return_address_manager_, PatchCallchain)
-      .Times(1)
-      .WillOnce(Invoke(fake_patch_callchain));
+  EXPECT_CALL(return_address_manager_, PatchCallchain).Times(1).WillOnce(fake_patch_callchain);
 
   EXPECT_CALL(leaf_function_call_manager_, PatchCallerOfLeafFunction)
       .Times(1)
@@ -503,7 +500,7 @@ TEST_F(UprobesUnwindingVisitorCallchainTest,
   };
   EXPECT_CALL(leaf_function_call_manager_, PatchCallerOfLeafFunction)
       .Times(1)
-      .WillOnce(Invoke(fake_patch_caller_of_leaf_function));
+      .WillOnce(fake_patch_caller_of_leaf_function);
 
   orbit_grpc_protos::FullCallstackSample actual_callstack_sample;
   EXPECT_CALL(listener_, OnCallstackSample).Times(1).WillOnce(SaveArg<0>(&actual_callstack_sample));

--- a/src/LinuxTracing/UprobesUnwindingVisitorDwarfUnwindingTest.cpp
+++ b/src/LinuxTracing/UprobesUnwindingVisitorDwarfUnwindingTest.cpp
@@ -264,9 +264,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
       [&actual_address_infos](orbit_grpc_protos::FullAddressInfo actual_address_info) {
         actual_address_infos.push_back(std::move(actual_address_info));
       };
-  EXPECT_CALL(this->listener_, OnAddressInfo)
-      .Times(3)
-      .WillRepeatedly(::testing::Invoke(save_address_info));
+  EXPECT_CALL(this->listener_, OnAddressInfo).Times(3).WillRepeatedly(save_address_info);
 
   std::atomic<uint64_t> unwinding_errors = 0;
   std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;
@@ -344,13 +342,11 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
     actual_callstack_samples.push_back(std::move(actual_callstack_sample));
   };
   if constexpr (std::is_same_v<StackSamplePerfEvent, typename TypeParam::PerfEventT>) {
-    EXPECT_CALL(this->listener_, OnCallstackSample)
-        .Times(2)
-        .WillRepeatedly(::testing::Invoke(save_callstack));
+    EXPECT_CALL(this->listener_, OnCallstackSample).Times(2).WillRepeatedly(save_callstack);
   } else {
     EXPECT_CALL(this->listener_, OnThreadStateSliceCallstack)
         .Times(2)
-        .WillRepeatedly(::testing::Invoke(save_callstack));
+        .WillRepeatedly(save_callstack);
   }
 
   std::vector<orbit_grpc_protos::FullAddressInfo> actual_address_infos;
@@ -358,9 +354,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
       [&actual_address_infos](orbit_grpc_protos::FullAddressInfo actual_address_info) {
         actual_address_infos.push_back(std::move(actual_address_info));
       };
-  EXPECT_CALL(this->listener_, OnAddressInfo)
-      .Times(3)
-      .WillRepeatedly(::testing::Invoke(save_address_info));
+  EXPECT_CALL(this->listener_, OnAddressInfo).Times(3).WillRepeatedly(save_address_info);
 
   std::atomic<uint64_t> unwinding_errors = 0;
   std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;
@@ -452,9 +446,7 @@ TYPED_TEST_P(
       [&actual_address_infos](orbit_grpc_protos::FullAddressInfo actual_address_info) {
         actual_address_infos.push_back(std::move(actual_address_info));
       };
-  EXPECT_CALL(this->listener_, OnAddressInfo)
-      .Times(3)
-      .WillRepeatedly(::testing::Invoke(save_address_info));
+  EXPECT_CALL(this->listener_, OnAddressInfo).Times(3).WillRepeatedly(save_address_info);
 
   std::atomic<uint64_t> unwinding_errors = 0;
   std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;
@@ -564,9 +556,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
       [&actual_address_infos](orbit_grpc_protos::FullAddressInfo actual_address_info) {
         actual_address_infos.push_back(std::move(actual_address_info));
       };
-  EXPECT_CALL(this->listener_, OnAddressInfo)
-      .Times(2)
-      .WillRepeatedly(::testing::Invoke(save_address_info));
+  EXPECT_CALL(this->listener_, OnAddressInfo).Times(2).WillRepeatedly(save_address_info);
 
   std::atomic<uint64_t> unwinding_errors = 0;
   std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;
@@ -634,9 +624,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
       [&actual_address_infos](orbit_grpc_protos::FullAddressInfo actual_address_info) {
         actual_address_infos.push_back(std::move(actual_address_info));
       };
-  EXPECT_CALL(this->listener_, OnAddressInfo)
-      .Times(1)
-      .WillRepeatedly(::testing::Invoke(save_address_info));
+  EXPECT_CALL(this->listener_, OnAddressInfo).Times(1).WillRepeatedly(save_address_info);
 
   std::atomic<uint64_t> unwinding_errors = 0;
   std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;
@@ -696,9 +684,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
       [&actual_address_infos](orbit_grpc_protos::FullAddressInfo actual_address_info) {
         actual_address_infos.push_back(std::move(actual_address_info));
       };
-  EXPECT_CALL(this->listener_, OnAddressInfo)
-      .Times(1)
-      .WillRepeatedly(::testing::Invoke(save_address_info));
+  EXPECT_CALL(this->listener_, OnAddressInfo).Times(1).WillRepeatedly(save_address_info);
 
   std::atomic<uint64_t> unwinding_errors = 0;
   std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;
@@ -758,9 +744,7 @@ TYPED_TEST_P(
       [&actual_address_infos](orbit_grpc_protos::FullAddressInfo actual_address_info) {
         actual_address_infos.push_back(std::move(actual_address_info));
       };
-  EXPECT_CALL(this->listener_, OnAddressInfo)
-      .Times(1)
-      .WillRepeatedly(::testing::Invoke(save_address_info));
+  EXPECT_CALL(this->listener_, OnAddressInfo).Times(1).WillRepeatedly(save_address_info);
 
   std::atomic<uint64_t> unwinding_errors = 0;
   std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;
@@ -818,9 +802,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
       [&actual_address_infos](orbit_grpc_protos::FullAddressInfo actual_address_info) {
         actual_address_infos.push_back(std::move(actual_address_info));
       };
-  EXPECT_CALL(this->listener_, OnAddressInfo)
-      .Times(2)
-      .WillRepeatedly(::testing::Invoke(save_address_info));
+  EXPECT_CALL(this->listener_, OnAddressInfo).Times(2).WillRepeatedly(save_address_info);
 
   std::atomic<uint64_t> unwinding_errors = 0;
   std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;
@@ -890,9 +872,7 @@ TYPED_TEST_P(
       [&actual_address_infos](orbit_grpc_protos::FullAddressInfo actual_address_info) {
         actual_address_infos.push_back(std::move(actual_address_info));
       };
-  EXPECT_CALL(this->listener_, OnAddressInfo)
-      .Times(2)
-      .WillRepeatedly(::testing::Invoke(save_address_info));
+  EXPECT_CALL(this->listener_, OnAddressInfo).Times(2).WillRepeatedly(save_address_info);
 
   std::atomic<uint64_t> unwinding_errors = 0;
   std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;
@@ -963,9 +943,7 @@ TYPED_TEST_P(
       [&actual_address_infos](orbit_grpc_protos::FullAddressInfo actual_address_info) {
         actual_address_infos.push_back(std::move(actual_address_info));
       };
-  EXPECT_CALL(this->listener_, OnAddressInfo)
-      .Times(4)
-      .WillRepeatedly(::testing::Invoke(save_address_info));
+  EXPECT_CALL(this->listener_, OnAddressInfo).Times(4).WillRepeatedly(save_address_info);
 
   std::atomic<uint64_t> unwinding_errors = 0;
   std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;
@@ -1054,9 +1032,7 @@ TYPED_TEST_P(
       [&actual_address_infos](orbit_grpc_protos::FullAddressInfo actual_address_info) {
         actual_address_infos.push_back(std::move(actual_address_info));
       };
-  EXPECT_CALL(this->listener_, OnAddressInfo)
-      .Times(3)
-      .WillRepeatedly(::testing::Invoke(save_address_info));
+  EXPECT_CALL(this->listener_, OnAddressInfo).Times(3).WillRepeatedly(save_address_info);
 
   std::atomic<uint64_t> unwinding_errors = 0;
   std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;
@@ -1133,9 +1109,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
       [&actual_address_infos](orbit_grpc_protos::FullAddressInfo actual_address_info) {
         actual_address_infos.push_back(std::move(actual_address_info));
       };
-  EXPECT_CALL(this->listener_, OnAddressInfo)
-      .Times(2)
-      .WillRepeatedly(::testing::Invoke(save_address_info));
+  EXPECT_CALL(this->listener_, OnAddressInfo).Times(2).WillRepeatedly(save_address_info);
 
   std::atomic<uint64_t> unwinding_errors = 0;
   std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;
@@ -1205,9 +1179,7 @@ TYPED_TEST_P(
       [&actual_address_infos](orbit_grpc_protos::FullAddressInfo actual_address_info) {
         actual_address_infos.push_back(std::move(actual_address_info));
       };
-  EXPECT_CALL(this->listener_, OnAddressInfo)
-      .Times(2)
-      .WillRepeatedly(::testing::Invoke(save_address_info));
+  EXPECT_CALL(this->listener_, OnAddressInfo).Times(2).WillRepeatedly(save_address_info);
 
   std::atomic<uint64_t> unwinding_errors = 0;
   std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;
@@ -1278,9 +1250,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest, VisitStackSampleUsesUser
       [&actual_address_infos](orbit_grpc_protos::FullAddressInfo actual_address_info) {
         actual_address_infos.push_back(std::move(actual_address_info));
       };
-  EXPECT_CALL(this->listener_, OnAddressInfo)
-      .Times(3)
-      .WillRepeatedly(::testing::Invoke(save_address_info));
+  EXPECT_CALL(this->listener_, OnAddressInfo).Times(3).WillRepeatedly(save_address_info);
 
   std::atomic<uint64_t> unwinding_errors = 0;
   std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;
@@ -1394,9 +1364,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
       [&actual_address_infos](orbit_grpc_protos::FullAddressInfo actual_address_info) {
         actual_address_infos.push_back(std::move(actual_address_info));
       };
-  EXPECT_CALL(this->listener_, OnAddressInfo)
-      .Times(3)
-      .WillRepeatedly(::testing::Invoke(save_address_info));
+  EXPECT_CALL(this->listener_, OnAddressInfo).Times(3).WillRepeatedly(save_address_info);
 
   std::atomic<uint64_t> unwinding_errors = 0;
   std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;
@@ -1530,9 +1498,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
       [&actual_address_infos](orbit_grpc_protos::FullAddressInfo actual_address_info) {
         actual_address_infos.push_back(std::move(actual_address_info));
       };
-  EXPECT_CALL(this->listener_, OnAddressInfo)
-      .Times(3)
-      .WillRepeatedly(::testing::Invoke(save_address_info));
+  EXPECT_CALL(this->listener_, OnAddressInfo).Times(3).WillRepeatedly(save_address_info);
 
   std::atomic<uint64_t> unwinding_errors = 0;
   std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;
@@ -1666,9 +1632,7 @@ TYPED_TEST_P(UprobesUnwindingVisitorDwarfUnwindingTest,
       [&actual_address_infos](orbit_grpc_protos::FullAddressInfo actual_address_info) {
         actual_address_infos.push_back(std::move(actual_address_info));
       };
-  EXPECT_CALL(this->listener_, OnAddressInfo)
-      .Times(3)
-      .WillRepeatedly(::testing::Invoke(save_address_info));
+  EXPECT_CALL(this->listener_, OnAddressInfo).Times(3).WillRepeatedly(save_address_info);
 
   std::atomic<uint64_t> unwinding_errors = 0;
   std::atomic<uint64_t> discarded_samples_in_uretprobes_counter = 0;

--- a/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/LinuxTracingIntegrationTest.cpp
@@ -91,11 +91,11 @@ class BufferTracerListener : public orbit_linux_tracing::TracerListener {
     orbit_grpc_protos::ProducerCaptureEvent event;
     *event.mutable_scheduling_slice() = std::move(scheduling_slice);
     {
-      absl::MutexLock lock{&events_mutex_};
+      absl::MutexLock lock{events_mutex_};
       events_.emplace_back(std::move(event));
     }
     {
-      absl::MutexLock lock{&one_scheduling_slice_received_mutex_};
+      absl::MutexLock lock{one_scheduling_slice_received_mutex_};
       one_scheduling_slice_received_ = true;
     }
   }
@@ -104,7 +104,7 @@ class BufferTracerListener : public orbit_linux_tracing::TracerListener {
     orbit_grpc_protos::ProducerCaptureEvent event;
     *event.mutable_full_callstack_sample() = std::move(callstack_sample);
     {
-      absl::MutexLock lock{&events_mutex_};
+      absl::MutexLock lock{events_mutex_};
       events_.emplace_back(std::move(event));
     }
   }
@@ -113,7 +113,7 @@ class BufferTracerListener : public orbit_linux_tracing::TracerListener {
     orbit_grpc_protos::ProducerCaptureEvent event;
     *event.mutable_function_call() = std::move(function_call);
     {
-      absl::MutexLock lock{&events_mutex_};
+      absl::MutexLock lock{events_mutex_};
       events_.emplace_back(std::move(event));
     }
   }
@@ -122,7 +122,7 @@ class BufferTracerListener : public orbit_linux_tracing::TracerListener {
     orbit_grpc_protos::ProducerCaptureEvent event;
     *event.mutable_full_gpu_job() = std::move(full_gpu_job_event);
     {
-      absl::MutexLock lock{&events_mutex_};
+      absl::MutexLock lock{events_mutex_};
       events_.emplace_back(std::move(event));
     }
   }
@@ -131,7 +131,7 @@ class BufferTracerListener : public orbit_linux_tracing::TracerListener {
     orbit_grpc_protos::ProducerCaptureEvent event;
     *event.mutable_thread_name() = std::move(thread_name);
     {
-      absl::MutexLock lock{&events_mutex_};
+      absl::MutexLock lock{events_mutex_};
       events_.emplace_back(std::move(event));
     }
   }
@@ -141,7 +141,7 @@ class BufferTracerListener : public orbit_linux_tracing::TracerListener {
     orbit_grpc_protos::ProducerCaptureEvent event;
     *event.mutable_thread_names_snapshot() = std::move(thread_names_snapshot);
     {
-      absl::MutexLock lock{&events_mutex_};
+      absl::MutexLock lock{events_mutex_};
       events_.emplace_back(std::move(event));
     }
   }
@@ -150,7 +150,7 @@ class BufferTracerListener : public orbit_linux_tracing::TracerListener {
     orbit_grpc_protos::ProducerCaptureEvent event;
     *event.mutable_thread_state_slice() = std::move(thread_state_slice);
     {
-      absl::MutexLock lock{&events_mutex_};
+      absl::MutexLock lock{events_mutex_};
       events_.emplace_back(std::move(event));
     }
   }
@@ -164,7 +164,7 @@ class BufferTracerListener : public orbit_linux_tracing::TracerListener {
     orbit_grpc_protos::ProducerCaptureEvent event;
     *event.mutable_full_address_info() = std::move(address_info);
     {
-      absl::MutexLock lock{&events_mutex_};
+      absl::MutexLock lock{events_mutex_};
       events_.emplace_back(std::move(event));
     }
   }
@@ -173,7 +173,7 @@ class BufferTracerListener : public orbit_linux_tracing::TracerListener {
     orbit_grpc_protos::ProducerCaptureEvent event;
     *event.mutable_full_tracepoint_event() = std::move(tracepoint_event);
     {
-      absl::MutexLock lock{&events_mutex_};
+      absl::MutexLock lock{events_mutex_};
       events_.emplace_back(std::move(event));
     }
   }
@@ -182,7 +182,7 @@ class BufferTracerListener : public orbit_linux_tracing::TracerListener {
     orbit_grpc_protos::ProducerCaptureEvent event;
     *event.mutable_module_update_event() = std::move(module_update_event);
     {
-      absl::MutexLock lock{&events_mutex_};
+      absl::MutexLock lock{events_mutex_};
       events_.emplace_back(std::move(event));
     }
   }
@@ -191,7 +191,7 @@ class BufferTracerListener : public orbit_linux_tracing::TracerListener {
     orbit_grpc_protos::ProducerCaptureEvent event;
     *event.mutable_modules_snapshot() = std::move(modules_snapshot);
     {
-      absl::MutexLock lock{&events_mutex_};
+      absl::MutexLock lock{events_mutex_};
       events_.emplace_back(std::move(event));
     }
   }
@@ -202,7 +202,7 @@ class BufferTracerListener : public orbit_linux_tracing::TracerListener {
     *event.mutable_errors_with_perf_event_open_event() =
         std::move(errors_with_perf_event_open_event);
     {
-      absl::MutexLock lock{&events_mutex_};
+      absl::MutexLock lock{events_mutex_};
       events_.emplace_back(std::move(event));
     }
   }
@@ -212,7 +212,7 @@ class BufferTracerListener : public orbit_linux_tracing::TracerListener {
     orbit_grpc_protos::ProducerCaptureEvent event;
     *event.mutable_lost_perf_records_event() = std::move(lost_perf_records_event);
     {
-      absl::MutexLock lock{&events_mutex_};
+      absl::MutexLock lock{events_mutex_};
       events_.emplace_back(std::move(event));
     }
   }
@@ -223,7 +223,7 @@ class BufferTracerListener : public orbit_linux_tracing::TracerListener {
     *event.mutable_out_of_order_events_discarded_event() =
         std::move(out_of_order_events_discarded_event);
     {
-      absl::MutexLock lock{&events_mutex_};
+      absl::MutexLock lock{events_mutex_};
       events_.emplace_back(std::move(event));
     }
   }
@@ -235,13 +235,13 @@ class BufferTracerListener : public orbit_linux_tracing::TracerListener {
     *event.mutable_warning_instrumenting_with_uprobes_event() =
         std::move(warning_instrumenting_with_uprobes_event);
     {
-      absl::MutexLock lock{&events_mutex_};
+      absl::MutexLock lock{events_mutex_};
       events_.emplace_back(std::move(event));
     }
   }
 
   [[nodiscard]] std::vector<orbit_grpc_protos::ProducerCaptureEvent> GetAndClearEvents() {
-    absl::MutexLock lock{&events_mutex_};
+    absl::MutexLock lock{events_mutex_};
     std::vector<orbit_grpc_protos::ProducerCaptureEvent> events = std::move(events_);
     events_.clear();
     return events;
@@ -251,7 +251,7 @@ class BufferTracerListener : public orbit_linux_tracing::TracerListener {
     one_scheduling_slice_received_mutex_.LockWhen(absl::Condition(
         +[](bool* one_scheduling_slice_received) { return *one_scheduling_slice_received; },
         &one_scheduling_slice_received_));
-    one_scheduling_slice_received_mutex_.Unlock();
+    one_scheduling_slice_received_mutex_.unlock();
   }
 
  private:

--- a/src/LinuxTracingIntegrationTests/OrbitServiceIntegrationTest.cpp
+++ b/src/LinuxTracingIntegrationTests/OrbitServiceIntegrationTest.cpp
@@ -132,7 +132,7 @@ class OrbitServiceIntegrationTestFixture {
     ORBIT_CHECK(capture_thread_.joinable());
 
     {
-      absl::ReaderMutexLock lock{&capture_reader_writer_mutex_};
+      absl::ReaderMutexLock lock{capture_reader_writer_mutex_};
       ORBIT_LOG("Stopping capture");
       bool writes_done_succeeded = capture_reader_writer_->WritesDone();
       ORBIT_CHECK(writes_done_succeeded);
@@ -142,7 +142,7 @@ class OrbitServiceIntegrationTestFixture {
 
     std::vector<ClientCaptureEvent> events;
     {
-      absl::MutexLock lock{&capture_events_mutex_};
+      absl::MutexLock lock{capture_events_mutex_};
       events = std::move(capture_events_);
       capture_events_.clear();
     }
@@ -158,13 +158,13 @@ class OrbitServiceIntegrationTestFixture {
         orbit_grpc_protos::CaptureService::NewStub(channel);
 
     {
-      absl::WriterMutexLock lock{&capture_reader_writer_mutex_};
+      absl::WriterMutexLock lock{capture_reader_writer_mutex_};
       ORBIT_CHECK(capture_reader_writer_ == nullptr);
       ORBIT_LOG("Starting capture");
       capture_reader_writer_ = capture_service->Capture(&context);
     }
     {
-      absl::ReaderMutexLock lock{&capture_reader_writer_mutex_};
+      absl::ReaderMutexLock lock{capture_reader_writer_mutex_};
       orbit_grpc_protos::CaptureRequest capture_request;
       *capture_request.mutable_capture_options() = std::move(capture_options);
       bool write_capture_request_result = capture_reader_writer_->Write(capture_request);
@@ -176,7 +176,7 @@ class OrbitServiceIntegrationTestFixture {
       orbit_grpc_protos::CaptureResponse capture_response;
       bool read_capture_response_result{};
       {
-        absl::ReaderMutexLock lock{&capture_reader_writer_mutex_};
+        absl::ReaderMutexLock lock{capture_reader_writer_mutex_};
         read_capture_response_result = capture_reader_writer_->Read(&capture_response);
       }
 
@@ -185,21 +185,21 @@ class OrbitServiceIntegrationTestFixture {
         break;
       }
       for (ClientCaptureEvent& event : *capture_response.mutable_capture_events()) {
-        absl::MutexLock lock{&capture_events_mutex_};
+        absl::MutexLock lock{capture_events_mutex_};
         capture_events_.emplace_back(std::move(event));
       }
     }
 
     ORBIT_LOG("Capture finished");
     {
-      absl::WriterMutexLock lock{&capture_reader_writer_mutex_};
+      absl::WriterMutexLock lock{capture_reader_writer_mutex_};
       ORBIT_CHECK(capture_reader_writer_ != nullptr);
       capture_reader_writer_ = nullptr;
     }
   }
 
   void WaitForFirstEvent() {
-    absl::MutexLock lock{&capture_events_mutex_};
+    absl::MutexLock lock{capture_events_mutex_};
     capture_events_mutex_.Await(absl::Condition(
         +[](std::vector<ClientCaptureEvent>* capture_events) { return !capture_events->empty(); },
         &capture_events_));

--- a/src/MemoryTracing/MemoryInfoListener.cpp
+++ b/src/MemoryTracing/MemoryInfoListener.cpp
@@ -63,7 +63,7 @@ void MemoryInfoListener::OnSystemMemoryUsage(
   uint64_t sampling_window_id = GetSamplingWindowId(
       system_memory_usage.timestamp_ns(), sampling_start_timestamp_ns_, sampling_period_ns_);
 
-  absl::MutexLock lock(&in_progress_memory_usage_events_mutex_);
+  absl::MutexLock lock(in_progress_memory_usage_events_mutex_);
   *in_progress_memory_usage_events_[sampling_window_id].mutable_system_memory_usage() =
       std::move(system_memory_usage);
   ProcessMemoryUsageEventIfReady(sampling_window_id);
@@ -74,7 +74,7 @@ void MemoryInfoListener::OnCGroupMemoryUsage(
   uint64_t sampling_window_id = GetSamplingWindowId(
       cgroup_memory_usage.timestamp_ns(), sampling_start_timestamp_ns_, sampling_period_ns_);
 
-  absl::MutexLock lock(&in_progress_memory_usage_events_mutex_);
+  absl::MutexLock lock(in_progress_memory_usage_events_mutex_);
   *in_progress_memory_usage_events_[sampling_window_id].mutable_cgroup_memory_usage() =
       std::move(cgroup_memory_usage);
   ProcessMemoryUsageEventIfReady(sampling_window_id);
@@ -85,7 +85,7 @@ void MemoryInfoListener::OnProcessMemoryUsage(
   uint64_t sampling_window_id = GetSamplingWindowId(
       process_memory_usage.timestamp_ns(), sampling_start_timestamp_ns_, sampling_period_ns_);
 
-  absl::MutexLock lock(&in_progress_memory_usage_events_mutex_);
+  absl::MutexLock lock(in_progress_memory_usage_events_mutex_);
   *in_progress_memory_usage_events_[sampling_window_id].mutable_process_memory_usage() =
       std::move(process_memory_usage);
   ProcessMemoryUsageEventIfReady(sampling_window_id);

--- a/src/MemoryTracing/MemoryInfoProducer.cpp
+++ b/src/MemoryTracing/MemoryInfoProducer.cpp
@@ -37,7 +37,7 @@ void MemoryInfoProducer::Stop() {
 }
 
 void MemoryInfoProducer::SetExitRequested(bool exit_requested) {
-  absl::MutexLock lock(&exit_requested_mutex_);
+  absl::MutexLock lock(exit_requested_mutex_);
   exit_requested_ = exit_requested;
 }
 
@@ -48,7 +48,7 @@ void MemoryInfoProducer::Run() {
   ORBIT_CHECK(pid_ != kMissingInfo);
 
   absl::Time scheduled_time = absl::Now();
-  absl::MutexLock lock(&exit_requested_mutex_);
+  absl::MutexLock lock(exit_requested_mutex_);
   while (!exit_requested_) {
     producer_run_fn_(listener_, pid_);
     scheduled_time += absl::Nanoseconds(sampling_period_ns_);

--- a/src/MemoryTracing/MemoryTracingIntegrationTest.cpp
+++ b/src/MemoryTracing/MemoryTracingIntegrationTest.cpp
@@ -40,7 +40,7 @@ using orbit_memory_tracing::MemoryInfoProducer;
 class BufferMemoryInfoListener : public MemoryInfoListener {
  public:
   [[nodiscard]] std::vector<ProducerCaptureEvent> GetAndClearEvents() {
-    absl::MutexLock lock{&events_mutex_};
+    absl::MutexLock lock{events_mutex_};
     std::vector<ProducerCaptureEvent> events = std::move(events_);
     events_.clear();
     return events;
@@ -51,7 +51,7 @@ class BufferMemoryInfoListener : public MemoryInfoListener {
     ProducerCaptureEvent event;
     *event.mutable_memory_usage_event() = std::move(memory_usage_event);
 
-    absl::MutexLock lock{&events_mutex_};
+    absl::MutexLock lock{events_mutex_};
     events_.emplace_back(std::move(event));
   }
 

--- a/src/Orbit/main.cpp
+++ b/src/Orbit/main.cpp
@@ -228,12 +228,15 @@ int main(int argc, char* argv[]) {
   // Skip program name in positional_args[0].
   std::vector<std::string> capture_file_paths(positional_args.begin() + 1, positional_args.end());
 
-  std::filesystem::path log_file{orbit_paths::GetLogFilePathUnsafe()};
-  orbit_base::InitLogFile(log_file);
+  ErrorMessageOr<std::filesystem::path> log_dir_or_error = orbit_paths::CreateOrGetLogDir();
+  if (log_dir_or_error.has_error()) {
+    ORBIT_FATAL("Unable to create the log directory: %s", log_dir_or_error.error().message());
+  }
+  orbit_base::InitLogFile(log_dir_or_error.value() / orbit_base::GetLogFileName());
   ORBIT_LOG("You are running Orbit Profiler version %s", orbit_version::GetVersionString());
   LogCommandLine(argc, argv);
   ErrorMessageOr<void> remove_old_log_result =
-      orbit_base::TryRemoveOldLogFiles(orbit_paths::CreateOrGetLogDirUnsafe());
+      orbit_base::TryRemoveOldLogFiles(log_dir_or_error.value());
   if (remove_old_log_result.has_error()) {
     ORBIT_LOG("Warning: Unable to remove some old log files:\n%s",
               remove_old_log_result.error().message());

--- a/src/OrbitBase/Logging.cpp
+++ b/src/OrbitBase/Logging.cpp
@@ -44,7 +44,7 @@ ErrorMessageOr<void> TryRemoveOldLogFiles(const std::filesystem::path& log_dir) 
 }
 
 void InitLogFile(const std::filesystem::path& path) {
-  absl::MutexLock lock(&log_file_mutex);
+  absl::MutexLock lock(log_file_mutex);
   // Do not call CHECK here - it will end up calling LogToFile,
   // which tries to lock on the same mutex a second time. This will
   // lead to an error since the mutex is not recursive.
@@ -85,7 +85,7 @@ void LogStacktrace() {
 namespace orbit_base_internal {
 
 void LogToFile(std::string_view message) {
-  absl::MutexLock lock(&orbit_base::log_file_mutex);
+  absl::MutexLock lock(orbit_base::log_file_mutex);
   if (orbit_base::log_file.get() != nullptr) {
     // Ignore any errors that can happen, we cannot do anything about them at this point anyways.
     std::fwrite(message.data(), message.size(), 1, orbit_base::log_file.get());

--- a/src/OrbitBase/SimpleExecutor.cpp
+++ b/src/OrbitBase/SimpleExecutor.cpp
@@ -12,20 +12,20 @@
 
 namespace orbit_base {
 void SimpleExecutor::ScheduleImpl(std::unique_ptr<Action> action) {
-  absl::MutexLock lock{&mutex_};
+  absl::MutexLock lock{mutex_};
   scheduled_tasks_.emplace_back(std::move(action));
 }
 
 void SimpleExecutor::ExecuteScheduledTasks() {
   // Since each task can append to the list of scheduled tasks we have to make sure not to rely on
   // unstable iterators.
-  absl::MutexLock lock{&mutex_};
+  absl::MutexLock lock{mutex_};
   while (!scheduled_tasks_.empty()) {
     Action* action = scheduled_tasks_.front().get();
     {
-      mutex_.Unlock();
+      mutex_.unlock();
       action->Execute();
-      mutex_.Lock();
+      mutex_.lock();
     }
     scheduled_tasks_.pop_front();
   }

--- a/src/OrbitBase/StringConversion.cpp
+++ b/src/OrbitBase/StringConversion.cpp
@@ -9,6 +9,17 @@
 
 namespace orbit_base {
 
+// std::wstring_convert and <codecvt> are deprecated since C++17, but the standard does not offer a
+// replacement, so there is nothing to migrate to.
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif  // __GNUC__
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif  // _MSC_VER
+
 #ifdef _WIN32
 // On Windows, wchar_t is a 16-bit wide UTF-16 unicode character that we convert to and from UTF-8.
 using PlatformWStringConversionFacet = std::codecvt_utf8_utf16<wchar_t>;
@@ -26,5 +37,12 @@ std::wstring ToStdWString(std::string_view string) {
   std::wstring_convert<PlatformWStringConversionFacet> converter;
   return converter.from_bytes(string.data(), string.data() + string.length());
 }
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif  // __GNUC__
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // _MSC_VER
 
 }  // namespace orbit_base

--- a/src/OrbitBase/ThreadPool.cpp
+++ b/src/OrbitBase/ThreadPool.cpp
@@ -87,7 +87,7 @@ ThreadPoolImpl::ThreadPoolImpl(size_t thread_pool_min_size, size_t thread_pool_m
   // Ttl should not be too small
   ORBIT_CHECK(thread_ttl / absl::Nanoseconds(1) >= 1000);
 
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   for (size_t i = 0; i < thread_pool_min_size; ++i) {
     CreateWorker();
   }
@@ -108,7 +108,7 @@ void ThreadPoolImpl::ScheduleImpl(std::unique_ptr<Action> action) {
           ? CreateAction([this, action = std::move(action)]() mutable { run_action_(action); })
           : std::move(action);
 
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   ORBIT_CHECK(!shutdown_initiated_);
 
   scheduled_actions_.push_back(std::move(wrapped_action));
@@ -128,22 +128,22 @@ void ThreadPoolImpl::CleanupFinishedThreads() {
 }
 
 size_t ThreadPoolImpl::GetPoolSize() {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return worker_threads_.size();
 }
 
 size_t ThreadPoolImpl::GetNumberOfBusyThreads() {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return worker_threads_.size() - idle_threads_;
 }
 
 void ThreadPoolImpl::ShutdownInternal() {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   shutdown_initiated_ = true;
 }
 
 void ThreadPoolImpl::WaitInternal() {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   ORBIT_CHECK(shutdown_initiated_);
   // First wait until all worker threads finished their work
   // and moved to finished_threads_ list.
@@ -185,7 +185,7 @@ std::unique_ptr<Action> ThreadPoolImpl::TakeAction() {
 
 void ThreadPoolImpl::WorkerFunction() {
   while (true) {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     std::unique_ptr<Action> action = TakeAction();
 
     ORBIT_CHECK(idle_threads_ > 0);  // Sanity check
@@ -201,9 +201,9 @@ void ThreadPoolImpl::WorkerFunction() {
       break;
     }
 
-    mutex_.Unlock();
+    mutex_.unlock();
     action->Execute();
-    mutex_.Lock();
+    mutex_.lock();
     ++idle_threads_;
   }
 }
@@ -221,7 +221,7 @@ std::shared_ptr<ThreadPool> ThreadPool::Create(
 
 void ThreadPool::InitializeDefaultThreadPool() {
   {
-    absl::MutexLock lock(&g_default_thread_pool_mutex);
+    absl::MutexLock lock(g_default_thread_pool_mutex);
     ORBIT_CHECK(g_default_thread_pool == nullptr);
   }
   (void)GetDefaultThreadPool();
@@ -229,13 +229,13 @@ void ThreadPool::InitializeDefaultThreadPool() {
 
 void ThreadPool::SetDefaultThreadPool(const std::shared_ptr<ThreadPool>& thread_pool) {
   ORBIT_CHECK(thread_pool != nullptr);
-  absl::MutexLock lock(&g_default_thread_pool_mutex);
+  absl::MutexLock lock(g_default_thread_pool_mutex);
   ORBIT_CHECK(g_default_thread_pool == nullptr);
   g_default_thread_pool = thread_pool;
 }
 
 ThreadPool* ThreadPool::GetDefaultThreadPool() {
-  absl::MutexLock lock(&g_default_thread_pool_mutex);
+  absl::MutexLock lock(g_default_thread_pool_mutex);
   if (g_default_thread_pool != nullptr) {
     return g_default_thread_pool.get();
   }

--- a/src/OrbitBase/ThreadPoolTest.cpp
+++ b/src/OrbitBase/ThreadPoolTest.cpp
@@ -30,9 +30,9 @@ TEST(ThreadPool, Smoke) {
   bool called = false;
 
   {
-    absl::MutexLock lock(&mutex);
+    absl::MutexLock lock(mutex);
     thread_pool->Schedule([&]() {
-      absl::MutexLock lock(&mutex);
+      absl::MutexLock lock(mutex);
       called = true;
     });
 
@@ -63,10 +63,10 @@ TEST(ThreadPool, QueuedActionsExecutedOnShutdown) {
 
   constexpr size_t kNumberOfActions = 7;
   {
-    absl::MutexLock lock(&mutex);
+    absl::MutexLock lock(mutex);
     for (size_t i = 0; i < kNumberOfActions; ++i) {
       thread_pool->Schedule([&]() {
-        absl::MutexLock lock(&mutex);
+        absl::MutexLock lock(mutex);
         counter++;
       });
     }
@@ -97,27 +97,27 @@ TEST(ThreadPool, CheckTtl) {
   size_t actions_executed = 0;
 
   auto action = [&] {
-    actions_started_mutex.Lock();
+    actions_started_mutex.lock();
     actions_started++;
-    actions_started_mutex.Unlock();
+    actions_started_mutex.unlock();
 
-    absl::MutexLock lock(&actions_executed_mutex);
+    absl::MutexLock lock(actions_executed_mutex);
     actions_executed++;
   };
 
   constexpr size_t kNumberOfActions = 7;
   {
-    absl::MutexLock lock(&actions_executed_mutex);
+    absl::MutexLock lock(actions_executed_mutex);
     for (size_t i = 0; i < kNumberOfActions; ++i) {
       thread_pool->Schedule(action);
     }
     // Wait until actions are on worker threads
-    actions_started_mutex.Lock();
+    actions_started_mutex.lock();
     EXPECT_TRUE(actions_started_mutex.AwaitWithTimeout(
         absl::Condition(
             +[](size_t* started) { return *started == 5; }, &actions_started),
         absl::Milliseconds(50)));
-    actions_started_mutex.Unlock();
+    actions_started_mutex.unlock();
 
     // Now check the thread_pool size
     EXPECT_EQ(thread_pool->GetPoolSize(), kThreadPoolMaxSize);
@@ -155,38 +155,38 @@ TEST(ThreadPool, ExtendThreadPool) {
   size_t actions_executed = 0;
 
   auto action = [&] {
-    actions_started_mutex.Lock();
+    actions_started_mutex.lock();
     actions_started++;
-    actions_started_mutex.Unlock();
+    actions_started_mutex.unlock();
 
-    absl::MutexLock lock(&actions_executed_mutex);
+    absl::MutexLock lock(actions_executed_mutex);
     actions_executed++;
   };
 
   {
     // Schedule an action and check we have one worker thread
-    absl::MutexLock lock(&actions_executed_mutex);
+    absl::MutexLock lock(actions_executed_mutex);
     thread_pool->Schedule(action);
 
-    actions_started_mutex.Lock();
+    actions_started_mutex.lock();
     EXPECT_TRUE(actions_started_mutex.AwaitWithTimeout(
         absl::Condition(
             +[](size_t* started) { return *started == 1; }, &actions_started),
         absl::Milliseconds(100)))
         << "actions_started=" << actions_started << ", expected 1";
-    actions_started_mutex.Unlock();
+    actions_started_mutex.unlock();
 
     EXPECT_EQ(thread_pool->GetPoolSize(), 1);
 
     // Schedule another action and check that there are 2 workers threads now.
     thread_pool->Schedule(action);
 
-    actions_started_mutex.Lock();
+    actions_started_mutex.lock();
     EXPECT_TRUE(actions_started_mutex.AwaitWithTimeout(
         absl::Condition(
             +[](size_t* started) { return *started == 2; }, &actions_started),
         absl::Milliseconds(100)));
-    actions_started_mutex.Unlock();
+    actions_started_mutex.unlock();
 
     EXPECT_EQ(thread_pool->GetPoolSize(), 2);
 
@@ -200,9 +200,9 @@ TEST(ThreadPool, ExtendThreadPool) {
 
     EXPECT_EQ(thread_pool->GetPoolSize(), kThreadPoolMaxSize);
 
-    actions_started_mutex.Lock();
+    actions_started_mutex.lock();
     EXPECT_EQ(actions_started, kThreadPoolMaxSize);
-    actions_started_mutex.Unlock();
+    actions_started_mutex.unlock();
 
     EXPECT_TRUE(actions_executed_mutex.AwaitWithTimeout(
         absl::Condition(
@@ -222,26 +222,26 @@ TEST(ThreadPool, ExtendThreadPool) {
   // Now make sure thread_pool increases number of threads
   // correctly after reducing number of worker threads.
   {
-    absl::MutexLock lock(&actions_executed_mutex);
+    absl::MutexLock lock(actions_executed_mutex);
     thread_pool->Schedule(action);
 
-    actions_started_mutex.Lock();
+    actions_started_mutex.lock();
     EXPECT_TRUE(actions_started_mutex.AwaitWithTimeout(
         absl::Condition(
             +[](size_t* started) { return *started == 13; }, &actions_started),
         absl::Milliseconds(100)));
-    actions_started_mutex.Unlock();
+    actions_started_mutex.unlock();
 
     EXPECT_EQ(thread_pool->GetPoolSize(), 1);
 
     thread_pool->Schedule(action);
 
-    actions_started_mutex.Lock();
+    actions_started_mutex.lock();
     EXPECT_TRUE(actions_started_mutex.AwaitWithTimeout(
         absl::Condition(
             +[](size_t* started) { return *started == 14; }, &actions_started),
         absl::Milliseconds(100)));
-    actions_started_mutex.Unlock();
+    actions_started_mutex.unlock();
 
     EXPECT_EQ(thread_pool->GetPoolSize(), 2);
 
@@ -254,9 +254,9 @@ TEST(ThreadPool, ExtendThreadPool) {
     absl::SleepFor(absl::Milliseconds(50));
 
     EXPECT_EQ(thread_pool->GetPoolSize(), kThreadPoolMaxSize);
-    actions_started_mutex.Lock();
+    actions_started_mutex.lock();
     EXPECT_EQ(actions_started, 12 + kThreadPoolMaxSize);
-    actions_started_mutex.Unlock();
+    actions_started_mutex.unlock();
   }
 
   thread_pool->ShutdownAndWait();
@@ -281,37 +281,37 @@ TEST(ThreadPool, CheckGetNumberOfBusyThreads) {
   size_t actions_executed = 0;
 
   auto action = [&] {
-    actions_started_mutex.Lock();
+    actions_started_mutex.lock();
     actions_started++;
-    actions_started_mutex.Unlock();
+    actions_started_mutex.unlock();
 
-    absl::MutexLock lock(&actions_executed_mutex);
+    absl::MutexLock lock(actions_executed_mutex);
     actions_executed++;
   };
 
   {
     // Schedule an action and check we have a busy thread
-    absl::MutexLock lock(&actions_executed_mutex);
+    absl::MutexLock lock(actions_executed_mutex);
     thread_pool->Schedule(action);
 
-    actions_started_mutex.Lock();
+    actions_started_mutex.lock();
     EXPECT_TRUE(actions_started_mutex.AwaitWithTimeout(
         absl::Condition(
             +[](size_t* started) { return *started == 1; }, &actions_started),
         absl::Milliseconds(100)))
         << "actions_started=" << actions_started << ", expected 1";
-    actions_started_mutex.Unlock();
+    actions_started_mutex.unlock();
     EXPECT_EQ(thread_pool->GetNumberOfBusyThreads(), 1);
 
     // Schedule another action and check that there are 2 workers threads now.
     thread_pool->Schedule(action);
 
-    actions_started_mutex.Lock();
+    actions_started_mutex.lock();
     EXPECT_TRUE(actions_started_mutex.AwaitWithTimeout(
         absl::Condition(
             +[](size_t* started) { return *started == 2; }, &actions_started),
         absl::Milliseconds(100)));
-    actions_started_mutex.Unlock();
+    actions_started_mutex.unlock();
     EXPECT_EQ(thread_pool->GetNumberOfBusyThreads(), 2);
 
     EXPECT_TRUE(actions_executed_mutex.AwaitWithTimeout(
@@ -407,9 +407,9 @@ TEST(ThreadPool, FutureBasic) {
   bool called = false;
 
   {
-    absl::MutexLock lock(&mutex);
+    absl::MutexLock lock(mutex);
     orbit_base::Future<void> future = thread_pool->Schedule([&]() {
-      absl::MutexLock lock(&mutex);
+      absl::MutexLock lock(mutex);
       called = true;
     });
 
@@ -442,9 +442,8 @@ TEST(ThreadPool, FutureContinuation) {
   std::atomic_bool called = false;
 
   {
-    absl::MutexLock lock(&mutex);
-    orbit_base::Future<void> future =
-        thread_pool->Schedule([&]() { absl::MutexLock lock(&mutex); });
+    absl::MutexLock lock(mutex);
+    orbit_base::Future<void> future = thread_pool->Schedule([&]() { absl::MutexLock lock(mutex); });
 
     auto const result = future.RegisterContinuation([&]() { called.store(true); });
     EXPECT_EQ(result, orbit_base::FutureRegisterContinuationResult::kSuccessfullyRegistered);
@@ -489,15 +488,15 @@ TEST(ThreadPool, FutureWithMoveOnlyResult) {
   absl::Mutex mutex;
 
   {
-    mutex.Lock();
+    mutex.lock();
     orbit_base::Future<MoveOnlyInt> future = thread_pool->Schedule([&]() {
-      absl::MutexLock lock(&mutex);
+      absl::MutexLock lock(mutex);
       return MoveOnlyInt{42};
     });
 
     EXPECT_TRUE(future.IsValid());
     EXPECT_FALSE(future.IsFinished());
-    mutex.Unlock();
+    mutex.unlock();
 
     EXPECT_TRUE(future.IsValid());
     EXPECT_EQ(future.Get().GetInt(), 42);
@@ -527,14 +526,14 @@ TEST(ThreadPool, WithRunActionParameter) {
   absl::Mutex mutex;
   bool called = false;
   {
-    absl::MutexLock called_lock(&mutex);
+    absl::MutexLock called_lock(mutex);
     int run_before_action_count_during_execution = -1;
     int run_after_action_count_during_execution = -1;
 
     thread_pool->Schedule([&]() {
       run_before_action_count_during_execution = run_before_action_count;
       run_after_action_count_during_execution = run_after_action_count;
-      absl::MutexLock called_lock(&mutex);
+      absl::MutexLock called_lock(mutex);
       called = true;
     });
 

--- a/src/OrbitBase/ThreadUtilsTest.cpp
+++ b/src/OrbitBase/ThreadUtilsTest.cpp
@@ -77,11 +77,11 @@ TEST(ThreadUtils, GetThreadName) {
   std::thread other_thread{[&mutex, &other_tid, &other_name_read] {
     orbit_base::SetCurrentThreadName(kThreadName);
     {
-      absl::MutexLock lock{&mutex};
+      absl::MutexLock lock{mutex};
       other_tid = orbit_base::GetCurrentThreadId();
     }
     {
-      absl::MutexLock lock{&mutex};
+      absl::MutexLock lock{mutex};
       // Wait for the main thread to read this thread's name before exiting.
       mutex.Await(absl::Condition(
           +[](bool* other_name_read) { return *other_name_read; }, &other_name_read));
@@ -89,7 +89,7 @@ TEST(ThreadUtils, GetThreadName) {
   }};
 
   {
-    absl::MutexLock lock{&mutex};
+    absl::MutexLock lock{mutex};
     // Wait for other_thread to set its own name and communicate its pid.
     mutex.Await(absl::Condition(
         +[](uint32_t* other_tid) { return *other_tid != 0; }, &other_tid));
@@ -97,7 +97,7 @@ TEST(ThreadUtils, GetThreadName) {
   std::string other_name = orbit_base::GetThreadName(other_tid);
   EXPECT_EQ(other_name, kThreadName);
   {
-    absl::MutexLock lock{&mutex};
+    absl::MutexLock lock{mutex};
     other_name_read = true;
   }
   other_thread.join();

--- a/src/OrbitBase/WhenAll.cpp
+++ b/src/OrbitBase/WhenAll.cpp
@@ -23,7 +23,7 @@ Future<void> WhenAll(absl::Span<const Future<void>> futures) {
 
   auto shared_state = std::make_shared<orbit_base_internal::SharedStateWhenAll<void>>();
   {
-    absl::MutexLock lock{&shared_state->mutex};
+    absl::MutexLock lock{shared_state->mutex};
     shared_state->incomplete_futures = futures.size();
   }
 
@@ -31,7 +31,7 @@ Future<void> WhenAll(absl::Span<const Future<void>> futures) {
     ORBIT_CHECK(future.IsValid());
     orbit_base::FutureRegisterContinuationResult const result =
         future.RegisterContinuation([shared_state]() {
-          absl::MutexLock lock{&shared_state->mutex};
+          absl::MutexLock lock{shared_state->mutex};
           --shared_state->incomplete_futures;
 
           if (shared_state->incomplete_futures == 0) {
@@ -40,13 +40,13 @@ Future<void> WhenAll(absl::Span<const Future<void>> futures) {
         });
 
     if (result != orbit_base::FutureRegisterContinuationResult::kSuccessfullyRegistered) {
-      absl::MutexLock lock{&shared_state->mutex};
+      absl::MutexLock lock{shared_state->mutex};
       --shared_state->incomplete_futures;
     }
   }
 
   {
-    absl::MutexLock lock{&shared_state->mutex};
+    absl::MutexLock lock{shared_state->mutex};
     if (shared_state->incomplete_futures == 0) {
       shared_state->promise.MarkFinished();
     }

--- a/src/OrbitBase/include/OrbitBase/Executor.h
+++ b/src/OrbitBase/include/OrbitBase/Executor.h
@@ -37,7 +37,7 @@ class Executor : public std::enable_shared_from_this<Executor> {
       explicit HandleData(Executor* executor) : executor_{executor} {}
 
       void InvalidateHandle() {
-        absl::WriterMutexLock lock{&mutex_};
+        absl::WriterMutexLock lock{mutex_};
         executor_ = nullptr;
       }
     };
@@ -119,7 +119,7 @@ class Executor : public std::enable_shared_from_this<Executor> {
 
     auto continuation = [this, function_reference, executor_handle = GetExecutorHandle(),
                          promise = std::move(promise)](auto&&... argument) mutable {
-      absl::ReaderMutexLock lock{&executor_handle.data_->mutex_};
+      absl::ReaderMutexLock lock{executor_handle.data_->mutex_};
       if (executor_handle.data_->executor_ == nullptr) return;
 
       auto function_wrapper =
@@ -184,7 +184,7 @@ class Executor : public std::enable_shared_from_this<Executor> {
         // in the non-locked context.
         promise.SetResult(outcome::failure(argument.error()));
 
-        absl::ReaderMutexLock lock{&executor_handle.data_->mutex_};
+        absl::ReaderMutexLock lock{executor_handle.data_->mutex_};
         if (executor_handle.data_->executor_ == nullptr) return;
 
         executor_handle.data_->executor_->ScheduleImpl(CreateAction(
@@ -203,7 +203,7 @@ class Executor : public std::enable_shared_from_this<Executor> {
         waiting_continuations_.erase(function_reference);
       };
 
-      absl::ReaderMutexLock lock{&executor_handle.data_->mutex_};
+      absl::ReaderMutexLock lock{executor_handle.data_->mutex_};
       if (executor_handle.data_->executor_ == nullptr) return;
 
       executor_handle.data_->executor_->ScheduleImpl(
@@ -236,7 +236,7 @@ class Executor : public std::enable_shared_from_this<Executor> {
 
 template <typename F>
 auto TrySchedule(const Executor::Handle& handle, F&& function_object) {
-  absl::ReaderMutexLock lock{&handle.data_->mutex_};
+  absl::ReaderMutexLock lock{handle.data_->mutex_};
   if (handle.data_->executor_ == nullptr) {
     return std::optional<decltype(std::declval<Executor>().Schedule(function_object))>{};
   }

--- a/src/OrbitBase/include/OrbitBase/Future.h
+++ b/src/OrbitBase/include/OrbitBase/Future.h
@@ -65,7 +65,7 @@ class InternalFutureBase {
       Invocable&& continuation) const {
     if (!IsValid()) return FutureRegisterContinuationResult::kFutureNotValid;
 
-    absl::MutexLock lock{&this->shared_state_->mutex};
+    absl::MutexLock lock{this->shared_state_->mutex};
     if (this->shared_state_->IsFinished()) {
       return FutureRegisterContinuationResult::kFutureAlreadyCompleted;
     }
@@ -80,13 +80,13 @@ class InternalFutureBase {
   [[nodiscard]] bool IsFinished() const {
     if (this->shared_state_.use_count() == 0) return false;
 
-    absl::MutexLock lock{&this->shared_state_->mutex};
+    absl::MutexLock lock{this->shared_state_->mutex};
     return this->shared_state_->IsFinished();
   }
 
   void Wait() const {
     ORBIT_CHECK(IsValid());
-    absl::MutexLock lock{&this->shared_state_->mutex};
+    absl::MutexLock lock{this->shared_state_->mutex};
     this->shared_state_->mutex.Await(absl::Condition(
         +[](const std::shared_ptr<SharedState<T>>* shared_state) ABSL_EXCLUSIVE_LOCKS_REQUIRED(
              shared_state->get()->mutex) { return shared_state->get()->IsFinished(); },
@@ -130,7 +130,7 @@ class InternalFuture : public orbit_base_internal::InternalFutureBase<T, Derived
   const T& Get() const {
     this->Wait();
 
-    absl::MutexLock lock{&this->shared_state_->mutex};
+    absl::MutexLock lock{this->shared_state_->mutex};
     return this->shared_state_->result.value();
   }
 

--- a/src/OrbitBase/include/OrbitBase/Promise.h
+++ b/src/OrbitBase/include/OrbitBase/Promise.h
@@ -68,7 +68,7 @@ class Promise : public orbit_base_internal::PromiseBase<T> {
   using orbit_base_internal::PromiseBase<T>::PromiseBase;
 
   void SetResult(T result) {
-    absl::MutexLock lock{&this->shared_state_->mutex};
+    absl::MutexLock lock{this->shared_state_->mutex};
 
     for (auto& continuation : this->shared_state_->continuations) {
       continuation(result);
@@ -79,7 +79,7 @@ class Promise : public orbit_base_internal::PromiseBase<T> {
 
   [[nodiscard]] bool HasResult() const {
     if (!this->IsValid()) return false;
-    absl::MutexLock lock{&this->shared_state_->mutex};
+    absl::MutexLock lock{this->shared_state_->mutex};
     return this->shared_state_->result.has_value();
   }
 };
@@ -90,7 +90,7 @@ class Promise<void> : public orbit_base_internal::PromiseBase<void> {
   using PromiseBase<void>::PromiseBase;
 
   void MarkFinished() {
-    absl::MutexLock lock{&this->shared_state_->mutex};
+    absl::MutexLock lock{this->shared_state_->mutex};
 
     for (auto& continuation : this->shared_state_->continuations) {
       continuation();
@@ -101,7 +101,7 @@ class Promise<void> : public orbit_base_internal::PromiseBase<void> {
 
   [[nodiscard]] bool IsFinished() const {
     if (!IsValid()) return false;
-    absl::MutexLock lock{&this->shared_state_->mutex};
+    absl::MutexLock lock{this->shared_state_->mutex};
     return this->shared_state_->finished;
   }
 };

--- a/src/OrbitBase/include/OrbitBase/WhenAll.h
+++ b/src/OrbitBase/include/OrbitBase/WhenAll.h
@@ -47,13 +47,13 @@ class SharedStateWhenAll {
 
  public:
   void SetNumberOfFutures(size_t size) {
-    absl::MutexLock lock{&mutex};
+    absl::MutexLock lock{mutex};
     incomplete_futures = size;
     results.resize(size);
   }
 
   void SetResult(size_t index, const T& argument) {
-    absl::MutexLock lock{&mutex};
+    absl::MutexLock lock{mutex};
     if (!results[index].has_value()) {
       results[index] = argument;
       --incomplete_futures;
@@ -98,7 +98,7 @@ class SharedStateWhenAllTuple {
   template <size_t index>
   void SetResult(const typename std::tuple_element<index, std::tuple<Ts...>>::type& argument)
       ABSL_LOCKS_EXCLUDED(mutex) {
-    absl::MutexLock lock{&mutex};
+    absl::MutexLock lock{mutex};
     if (!std::get<index>(results).has_value()) {
       std::get<index>(results) = argument;
       --incomplete_futures;

--- a/src/OrbitBase/include/OrbitBase/WhenAny.h
+++ b/src/OrbitBase/include/OrbitBase/WhenAny.h
@@ -24,14 +24,14 @@ class SharedStateWhenAny {
   template <size_t index>
   void SetResult(const typename std::variant_alternative_t<index, std::variant<Ts...>>& argument)
       ABSL_LOCKS_EXCLUDED(mutex) {
-    absl::MutexLock lock{&mutex};
+    absl::MutexLock lock{mutex};
     if (promise.HasResult()) return;
 
     promise.SetResult(std::variant<Ts...>{std::in_place_index_t<index>{}, argument});
   }
 
   [[nodiscard]] orbit_base::Future<std::variant<Ts...>> GetFuture() const {
-    absl::MutexLock lock{&mutex};
+    absl::MutexLock lock{mutex};
     return promise.GetFuture();
   }
 

--- a/src/OrbitGl/MultivariateTimeSeries.cpp
+++ b/src/OrbitGl/MultivariateTimeSeries.cpp
@@ -20,45 +20,45 @@ MultivariateTimeSeries::MultivariateTimeSeries(std::vector<std::string> series_n
 }
 
 double MultivariateTimeSeries::GetMin() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return min_;
 }
 
 double MultivariateTimeSeries::GetMax() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return max_;
 }
 
 bool MultivariateTimeSeries::IsEmpty() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return time_to_series_values_.empty();
 }
 
 size_t MultivariateTimeSeries::GetTimeToSeriesValuesSize() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return time_to_series_values_.size();
 }
 
 uint64_t MultivariateTimeSeries::StartTimeInNs() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   ORBIT_CHECK(!time_to_series_values_.empty());
   return time_to_series_values_.begin()->first;
 }
 
 uint64_t MultivariateTimeSeries::EndTimeInNs() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   ORBIT_CHECK(!time_to_series_values_.empty());
   return time_to_series_values_.rbegin()->first;
 }
 
 std::vector<double> MultivariateTimeSeries::GetPreviousOrFirstEntry(uint64_t time) const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return GetPreviousOrFirstEntryIterator(time)->second;
 }
 
 std::vector<std::pair<uint64_t, std::vector<double>>>
 MultivariateTimeSeries::GetEntriesAffectedByTimeRange(uint64_t min_time, uint64_t max_time) const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   if (time_to_series_values_.empty() || min_time >= max_time ||
       min_time >= time_to_series_values_.rbegin()->first ||
       max_time <= time_to_series_values_.begin()->first) {
@@ -81,7 +81,7 @@ MultivariateTimeSeries::GetEntriesAffectedByTimeRange(uint64_t min_time, uint64_
 void MultivariateTimeSeries::AddValues(uint64_t timestamp_ns, absl::Span<const double> values) {
   ORBIT_CHECK(values.size() == series_names_.size());
 
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   time_to_series_values_[timestamp_ns] = std::vector(values.begin(), values.end());
   for (double value : values) UpdateMinAndMax(value);
 }

--- a/src/OrbitGl/OrbitApp.cpp
+++ b/src/OrbitGl/OrbitApp.cpp
@@ -348,7 +348,7 @@ void OrbitApp::OnCaptureStarted(const orbit_grpc_protos::CaptureStarted& capture
   // We need to block until initialization is complete to
   // avoid races when capture thread start processing data.
   absl::Mutex mutex;
-  absl::MutexLock mutex_lock(&mutex);
+  absl::MutexLock mutex_lock(mutex);
   bool initialization_complete = false;
 
   main_thread_executor_->Schedule([this, &initialization_complete, &mutex, &capture_started,
@@ -412,7 +412,7 @@ void OrbitApp::OnCaptureStarted(const orbit_grpc_protos::CaptureStarted& capture
       main_window_->AppendToCaptureLog(MainWindowInterface::CaptureLogSeverity::kWarning,
                                        absl::ZeroDuration(), warning_message);
     }
-    absl::MutexLock lock(&mutex);
+    absl::MutexLock lock(mutex);
     initialization_complete = true;
   });
 
@@ -823,8 +823,13 @@ static std::vector<std::filesystem::path> ListRegularFilesWithExtension(
 }
 
 void OrbitApp::ListPresets() {
+  ErrorMessageOr<std::filesystem::path> preset_dir_or_error = orbit_paths::CreateOrGetPresetDir();
+  if (preset_dir_or_error.has_error()) {
+    ORBIT_ERROR("Unable to create the preset directory: %s", preset_dir_or_error.error().message());
+    return;
+  }
   std::vector<std::filesystem::path> preset_filenames =
-      ListRegularFilesWithExtension(orbit_paths::CreateOrGetPresetDirUnsafe(), ".opr");
+      ListRegularFilesWithExtension(preset_dir_or_error.value(), ".opr");
   std::vector<PresetFile> presets;
   for (const std::filesystem::path& filename : preset_filenames) {
     ErrorMessageOr<PresetFile> preset_result = ReadPresetFromFile(filename);
@@ -847,6 +852,30 @@ void OrbitApp::RefreshCaptureView() {
   DoZoom = true;  // TODO: remove global, review logic
 }
 
+// FunctionInfo::GetAbsoluteAddress is deprecated because it cannot give a correct answer for a
+// module that is mapped more than once. The two callers below need an address in the running
+// process because they read its memory; TODO(b/191248550) tracks getting rid of that. Until then
+// this wrapper keeps the deprecation warning confined to a single place.
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif  // __GNUC__
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif  // _MSC_VER
+[[nodiscard]] static std::optional<uint64_t> GetAbsoluteAddressInProcess(
+    const FunctionInfo& function, const ProcessData& process, const ModuleData& module,
+    orbit_client_data::ModuleIdentifier module_identifier) {
+  return function.GetAbsoluteAddress(process, module, module_identifier);
+}
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif  // __GNUC__
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // _MSC_VER
+
 void OrbitApp::Disassemble(uint32_t pid, const FunctionInfo& function) {
   ORBIT_CHECK(process_ != nullptr);
   orbit_client_data::ModulePathAndBuildId module_path_and_build_id{
@@ -858,7 +887,7 @@ void OrbitApp::Disassemble(uint32_t pid, const FunctionInfo& function) {
 
   const bool is_64_bit = process_->is_64_bit();
   std::optional<uint64_t> absolute_address =
-      function.GetAbsoluteAddress(*process_, *module, module_identifier.value());
+      GetAbsoluteAddressInProcess(function, *process_, *module, module_identifier.value());
   if (!absolute_address.has_value()) {
     SendErrorToUi(
         "Error reading memory",
@@ -949,7 +978,7 @@ void OrbitApp::ShowSourceCode(const orbit_client_data::FunctionInfo& function) {
       ORBIT_CHECK(module_identifier.has_value());
 
       const auto absolute_address =
-          function.GetAbsoluteAddress(*process_, *module, module_identifier.value());
+          GetAbsoluteAddressInProcess(function, *process_, *module, module_identifier.value());
 
       if (!absolute_address.has_value()) {
         SendErrorToUi(
@@ -1108,10 +1137,12 @@ ErrorMessageOr<void> OrbitApp::SavePreset(std::string_view file_name) {
 }
 
 ErrorMessageOr<PresetFile> OrbitApp::ReadPresetFromFile(const std::filesystem::path& filename) {
-  std::filesystem::path file_path =
-      filename.is_absolute() ? filename : orbit_paths::CreateOrGetPresetDirUnsafe() / filename;
+  if (filename.is_absolute()) {
+    return orbit_preset_file::ReadPresetFromFile(filename);
+  }
 
-  return orbit_preset_file::ReadPresetFromFile(file_path);
+  OUTCOME_TRY(std::filesystem::path preset_dir, orbit_paths::CreateOrGetPresetDir());
+  return orbit_preset_file::ReadPresetFromFile(preset_dir / filename);
 }
 
 ErrorMessageOr<void> OrbitApp::OnLoadPreset(std::string_view filename) {
@@ -1217,9 +1248,18 @@ static std::unique_ptr<CaptureEventProcessor> CreateCaptureEventProcessor(
     CaptureListener* listener, std::string_view process_name,
     absl::flat_hash_set<uint64_t> frame_track_function_ids,
     const std::function<void(const ErrorMessage&)>& error_handler) {
-  std::filesystem::path file_path = orbit_paths::CreateOrGetCaptureDirUnsafe() /
-                                    orbit_client_model::capture_serializer::GenerateCaptureFileName(
-                                        process_name, absl::Now(), "_autosave");
+  ErrorMessageOr<std::filesystem::path> capture_dir_or_error = orbit_paths::CreateOrGetCaptureDir();
+  if (capture_dir_or_error.has_error()) {
+    error_handler(ErrorMessage{absl::StrFormat("Unable to set up automatic capture saving: %s",
+                                               capture_dir_or_error.error().message())});
+    return CaptureEventProcessor::CreateForCaptureListener(listener, std::nullopt,
+                                                           std::move(frame_track_function_ids));
+  }
+  const std::filesystem::path& capture_dir = capture_dir_or_error.value();
+
+  std::filesystem::path file_path =
+      capture_dir / orbit_client_model::capture_serializer::GenerateCaptureFileName(
+                        process_name, absl::Now(), "_autosave");
 
   uint64_t suffix_number = 0;
   while (true) {
@@ -1235,9 +1275,8 @@ static std::unique_ptr<CaptureEventProcessor> CreateCaptureEventProcessor(
     }
 
     std::string suffix = absl::StrFormat("_autosave(%d)", ++suffix_number);
-    file_path = orbit_paths::CreateOrGetCaptureDirUnsafe() /
-                orbit_client_model::capture_serializer::GenerateCaptureFileName(
-                    process_name, absl::Now(), suffix);
+    file_path = capture_dir / orbit_client_model::capture_serializer::GenerateCaptureFileName(
+                                  process_name, absl::Now(), suffix);
   }
 
   auto save_to_file_processor_or_error =

--- a/src/OrbitGl/PickingManager.cpp
+++ b/src/OrbitGl/PickingManager.cpp
@@ -13,7 +13,7 @@
 
 PickingId PickingManager::GetOrCreatePickableId(const std::shared_ptr<Pickable>& pickable,
                                                 BatcherId batcher_id) {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   uint32_t pickable_id = 0;
 
   auto it = pickable_pid_map_.find(pickable.get());
@@ -30,7 +30,7 @@ PickingId PickingManager::GetOrCreatePickableId(const std::shared_ptr<Pickable>&
 }
 
 void PickingManager::Reset() {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   pid_pickable_map_.clear();
   pickable_pid_map_.clear();
   pickable_id_counter_ = 0;
@@ -39,7 +39,7 @@ void PickingManager::Reset() {
 std::shared_ptr<Pickable> PickingManager::GetPickableFromId(PickingId id) const {
   ORBIT_CHECK(id.type == PickingType::kPickable);
 
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   auto it = pid_pickable_map_.find(id.element_id);
   if (it == pid_pickable_map_.end()) {
     return nullptr;
@@ -48,7 +48,7 @@ std::shared_ptr<Pickable> PickingManager::GetPickableFromId(PickingId id) const 
 }
 
 std::shared_ptr<Pickable> PickingManager::GetPicked() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   return currently_picked_.lock();
 }
 
@@ -58,7 +58,7 @@ void PickingManager::Pick(PickingId id, int x, int y) {
     picked->OnPick(x, y);
   }
 
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   currently_picked_ = picked;
 }
 
@@ -66,7 +66,7 @@ void PickingManager::Release() {
   auto picked = GetPicked();
   if (picked != nullptr) {
     picked->OnRelease();
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     currently_picked_.reset();
   }
 }
@@ -79,7 +79,7 @@ void PickingManager::Drag(int x, int y) const {
 }
 
 bool PickingManager::IsDragging() const {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   auto picked = currently_picked_.lock();
   return picked && picked->Draggable();
 }

--- a/src/OrbitGl/SymbolLoader.cpp
+++ b/src/OrbitGl/SymbolLoader.cpp
@@ -11,6 +11,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <filesystem>
 #include <memory>
 #include <type_traits>
 #include <utility>
@@ -27,6 +28,7 @@
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/NotFoundOr.h"
 #include "OrbitBase/StopToken.h"
+#include "OrbitPaths/Paths.h"
 #include "SymbolProvider/SymbolLoadingOutcome.h"
 #include "Symbols/SymbolUtils.h"
 
@@ -44,6 +46,17 @@ using orbit_symbol_provider::SymbolLoadingOutcome;
 
 namespace orbit_gl {
 
+// The cache directory has to exist for symbol loading to work at all, so a failure to create it is
+// fatal -- which is also what the deprecated CreateOrGetCacheDirUnsafe() used to do here.
+[[nodiscard]] static std::filesystem::path GetSymbolCacheDir() {
+  ErrorMessageOr<std::filesystem::path> cache_dir_or_error = orbit_paths::CreateOrGetCacheDir();
+  if (cache_dir_or_error.has_error()) {
+    ORBIT_FATAL("Unable to create the symbol cache directory: %s",
+                cache_dir_or_error.error().message());
+  }
+  return std::move(cache_dir_or_error.value());
+}
+
 SymbolLoader::SymbolLoader(
     AppInterface* app_interface, std::thread::id main_thread_id,
     orbit_base::ThreadPool* thread_pool, orbit_base::Executor* main_thread_executor,
@@ -54,7 +67,8 @@ SymbolLoader::SymbolLoader(
       thread_pool_{thread_pool},
       main_thread_executor_{main_thread_executor},
       process_manager_{process_manager},
-      module_identifier_provider{module_identifier_provider} {
+      module_identifier_provider{module_identifier_provider},
+      symbol_helper_{GetSymbolCacheDir()} {
   ORBIT_CHECK(app_interface_ != nullptr);
   ORBIT_CHECK(thread_pool_ != nullptr);
   ORBIT_CHECK(main_thread_executor_ != nullptr);

--- a/src/OrbitGl/TrackManager.cpp
+++ b/src/OrbitGl/TrackManager.cpp
@@ -64,7 +64,7 @@ TrackManager::TrackManager(TrackContainer* track_container, TimelineInfoInterfac
 }
 
 std::vector<Track*> TrackManager::GetAllTracks() const {
-  absl::ReaderMutexLock lock(&mutex_);
+  absl::ReaderMutexLock lock(mutex_);
   return GetAllTracksInternal();
 }
 
@@ -79,7 +79,7 @@ std::vector<Track*> TrackManager::GetAllTracksInternal() const {
 }
 
 std::vector<FrameTrack*> TrackManager::GetFrameTracks() const {
-  absl::ReaderMutexLock lock(&mutex_);
+  absl::ReaderMutexLock lock(mutex_);
   std::vector<FrameTrack*> tracks;
   for (const auto& [unused_id, track] : frame_tracks_) {
     tracks.push_back(track.get());
@@ -89,7 +89,7 @@ std::vector<FrameTrack*> TrackManager::GetFrameTracks() const {
 
 void TrackManager::SortTracks() {
   ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
-  absl::WriterMutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(mutex_);
   // Gather all tracks regardless of the process in sorted order
   std::vector<Track*> all_processes_sorted_tracks;
 
@@ -236,7 +236,7 @@ void TrackManager::DeletePendingTracks() {
 
 void TrackManager::InsertPendingFrameTracks() {
   ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
-  absl::WriterMutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(mutex_);
   // We are inserting the new frame tracks just after the last Frame Track with lower function_id
   // (and also after the Scheduler one).
   for (const auto& frame_track : pending_frame_tracks_) {
@@ -387,7 +387,7 @@ void TrackManager::AddFrameTrack(const std::shared_ptr<FrameTrack>& frame_track)
 
 void TrackManager::RemoveFrameTrack(uint64_t function_id) {
   ORBIT_CHECK(std::this_thread::get_id() == main_thread_id_);
-  absl::WriterMutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(mutex_);
   deleted_tracks_.push_back(frame_tracks_[function_id]);
   frame_tracks_.erase(function_id);
 
@@ -470,7 +470,7 @@ Track* TrackManager::GetOrCreateTrackFromTimerInfo(const TimerInfo& timer_info) 
 }
 
 SchedulerTrack* TrackManager::GetOrCreateSchedulerTrack() {
-  absl::WriterMutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(mutex_);
   if (scheduler_track_ == nullptr) {
     auto [unused, timer_data] = capture_data_->CreateTimerData();
     scheduler_track_ =
@@ -482,7 +482,7 @@ SchedulerTrack* TrackManager::GetOrCreateSchedulerTrack() {
 }
 
 ThreadTrack* TrackManager::GetOrCreateThreadTrack(uint32_t tid) {
-  absl::WriterMutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(mutex_);
   return GetOrCreateThreadTrackInternal(tid);
 }
 
@@ -501,7 +501,7 @@ ThreadTrack* TrackManager::GetOrCreateThreadTrackInternal(uint32_t tid) {
 }
 
 std::optional<ThreadTrack*> TrackManager::GetThreadTrack(uint32_t tid) const {
-  absl::ReaderMutexLock lock(&mutex_);
+  absl::ReaderMutexLock lock(mutex_);
   if (!thread_tracks_.contains(tid)) {
     return std::nullopt;
   }
@@ -510,7 +510,7 @@ std::optional<ThreadTrack*> TrackManager::GetThreadTrack(uint32_t tid) const {
 }
 
 GpuTrack* TrackManager::GetOrCreateGpuTrack(uint64_t timeline_hash) {
-  absl::WriterMutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(mutex_);
   std::string timeline =
       app_->GetStringManager()->Get(timeline_hash).value_or(std::to_string(timeline_hash));
   std::shared_ptr<GpuTrack> track = gpu_tracks_[timeline];
@@ -527,7 +527,7 @@ GpuTrack* TrackManager::GetOrCreateGpuTrack(uint64_t timeline_hash) {
 }
 
 VariableTrack* TrackManager::GetOrCreateVariableTrack(std::string_view name) {
-  absl::WriterMutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(mutex_);
 
   auto existing_track = variable_tracks_.find(name);
   if (existing_track != variable_tracks_.end()) return existing_track->second.get();
@@ -540,7 +540,7 @@ VariableTrack* TrackManager::GetOrCreateVariableTrack(std::string_view name) {
 }
 
 AsyncTrack* TrackManager::GetOrCreateAsyncTrack(std::string_view name) {
-  absl::WriterMutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(mutex_);
 
   auto existing_track = async_tracks_.find(name);
   if (existing_track != async_tracks_.end()) return existing_track->second.get();
@@ -555,7 +555,7 @@ AsyncTrack* TrackManager::GetOrCreateAsyncTrack(std::string_view name) {
 }
 
 FrameTrack* TrackManager::GetOrCreateFrameTrack(uint64_t function_id) {
-  absl::WriterMutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(mutex_);
   if (auto track_it = frame_tracks_.find(function_id); track_it != frame_tracks_.end()) {
     return track_it->second.get();
   }
@@ -576,22 +576,22 @@ FrameTrack* TrackManager::GetOrCreateFrameTrack(uint64_t function_id) {
 }
 
 SystemMemoryTrack* TrackManager::GetSystemMemoryTrack() const {
-  absl::ReaderMutexLock lock(&mutex_);
+  absl::ReaderMutexLock lock(mutex_);
   return system_memory_track_.get();
 }
 
 CGroupAndProcessMemoryTrack* TrackManager::GetCGroupAndProcessMemoryTrack() const {
-  absl::ReaderMutexLock lock(&mutex_);
+  absl::ReaderMutexLock lock(mutex_);
   return cgroup_and_process_memory_track_.get();
 }
 
 PageFaultsTrack* TrackManager::GetPageFaultsTrack() const {
-  absl::ReaderMutexLock lock(&mutex_);
+  absl::ReaderMutexLock lock(mutex_);
   return page_faults_track_.get();
 }
 
 SystemMemoryTrack* TrackManager::CreateAndGetSystemMemoryTrack() {
-  absl::WriterMutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(mutex_);
   if (system_memory_track_ == nullptr) {
     system_memory_track_ = std::make_shared<SystemMemoryTrack>(
         track_container_, timeline_info_, viewport_, layout_, module_manager_, capture_data_);
@@ -603,7 +603,7 @@ SystemMemoryTrack* TrackManager::CreateAndGetSystemMemoryTrack() {
 
 CGroupAndProcessMemoryTrack* TrackManager::CreateAndGetCGroupAndProcessMemoryTrack(
     std::string_view cgroup_name) {
-  absl::WriterMutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(mutex_);
   if (cgroup_and_process_memory_track_ == nullptr) {
     cgroup_and_process_memory_track_ = std::make_shared<CGroupAndProcessMemoryTrack>(
         track_container_, timeline_info_, viewport_, layout_, std::string{cgroup_name},
@@ -616,7 +616,7 @@ CGroupAndProcessMemoryTrack* TrackManager::CreateAndGetCGroupAndProcessMemoryTra
 
 PageFaultsTrack* TrackManager::CreateAndGetPageFaultsTrack(std::string_view cgroup_name,
                                                            uint64_t memory_sampling_period_ms) {
-  absl::WriterMutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(mutex_);
   if (page_faults_track_ == nullptr) {
     page_faults_track_ = std::make_shared<PageFaultsTrack>(
         track_container_, timeline_info_, viewport_, layout_, std::string{cgroup_name},
@@ -628,7 +628,7 @@ PageFaultsTrack* TrackManager::CreateAndGetPageFaultsTrack(std::string_view cgro
 
 // TODO(b/177200020): Move to TrackContainer after assuring to have only one thread in the UI.
 std::pair<uint64_t, uint64_t> TrackManager::GetTracksMinMaxTimestamps() const {
-  absl::ReaderMutexLock lock(&mutex_);
+  absl::ReaderMutexLock lock(mutex_);
   uint64_t min_time = std::numeric_limits<uint64_t>::max();
   uint64_t max_time = std::numeric_limits<uint64_t>::min();
 

--- a/src/OrbitGl/include/OrbitGl/SymbolLoader.h
+++ b/src/OrbitGl/include/OrbitGl/SymbolLoader.h
@@ -31,7 +31,6 @@
 #include "OrbitBase/StopSource.h"
 #include "OrbitBase/StopToken.h"
 #include "OrbitBase/ThreadPool.h"
-#include "OrbitPaths/Paths.h"
 #include "RemoteSymbolProvider/MicrosoftSymbolServerSymbolProvider.h"
 #include "Symbols/SymbolHelper.h"
 
@@ -139,7 +138,7 @@ class SymbolLoader {
   orbit_client_services::ProcessManager* process_manager_;
   const orbit_client_data::ModuleIdentifierProvider* module_identifier_provider;
 
-  orbit_symbols::SymbolHelper symbol_helper_{orbit_paths::CreateOrGetCacheDirUnsafe()};
+  orbit_symbols::SymbolHelper symbol_helper_;
 
   // TODO(b/243520787) The SymbolProvider related logic should be moved to the ProxySymbolProvider
   //  as planned in our symbol refactoring discussion.

--- a/src/OrbitPaths/Paths.cpp
+++ b/src/OrbitPaths/Paths.cpp
@@ -83,6 +83,12 @@ static void CreateDirectoryOrDie(const std::filesystem::path& directory) {
   }
 }
 
+// The implementations behind the deprecated CreateOrGet*Unsafe functions. They exist so that those
+// functions can build on each other without triggering deprecation warnings.
+static std::filesystem::path CreateOrGetOrbitAppDataDirOrDie();
+static std::filesystem::path CreateOrGetOrbitUserDataDirOrDie();
+static std::filesystem::path CreateOrGetLogDirOrDie();
+
 static ErrorMessageOr<std::filesystem::path> CreateAndGetConfigPath() {
   OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDir());
   std::filesystem::path config_dir = app_data_dir / kConfigFolderName;
@@ -96,7 +102,7 @@ ErrorMessageOr<std::filesystem::path> GetSymbolsFilePath() {
 }
 
 std::filesystem::path CreateOrGetCacheDirUnsafe() {
-  std::filesystem::path cache_dir = CreateOrGetOrbitAppDataDirUnsafe() / kCacheFolderName;
+  std::filesystem::path cache_dir = CreateOrGetOrbitAppDataDirOrDie() / kCacheFolderName;
   CreateDirectoryOrDie(cache_dir);
   return cache_dir;
 }
@@ -109,7 +115,7 @@ ErrorMessageOr<std::filesystem::path> CreateOrGetCacheDir() {
 }
 
 std::filesystem::path CreateOrGetPresetDirUnsafe() {
-  std::filesystem::path preset_dir = CreateOrGetOrbitUserDataDirUnsafe() / kPresetsFolderName;
+  std::filesystem::path preset_dir = CreateOrGetOrbitUserDataDirOrDie() / kPresetsFolderName;
   CreateDirectoryOrDie(preset_dir);
   return preset_dir;
 }
@@ -122,7 +128,7 @@ ErrorMessageOr<std::filesystem::path> CreateOrGetPresetDir() {
 }
 
 std::filesystem::path CreateOrGetCaptureDirUnsafe() {
-  std::filesystem::path capture_dir = CreateOrGetOrbitUserDataDirUnsafe() / kCapturesFolderName;
+  std::filesystem::path capture_dir = CreateOrGetOrbitUserDataDirOrDie() / kCapturesFolderName;
   CreateDirectoryOrDie(capture_dir);
   return capture_dir;
 }
@@ -135,7 +141,7 @@ ErrorMessageOr<std::filesystem::path> CreateOrGetCaptureDir() {
 }
 
 std::filesystem::path CreateOrGetDumpDirUnsafe() {
-  std::filesystem::path dumps_dir = CreateOrGetOrbitAppDataDirUnsafe() / kDumpsFolderName;
+  std::filesystem::path dumps_dir = CreateOrGetOrbitAppDataDirOrDie() / kDumpsFolderName;
   CreateDirectoryOrDie(dumps_dir);
   return dumps_dir;
 }
@@ -156,10 +162,14 @@ static std::filesystem::path GetOrbitAppDataDir() {
   return path;
 }
 
-std::filesystem::path CreateOrGetOrbitAppDataDirUnsafe() {
+static std::filesystem::path CreateOrGetOrbitAppDataDirOrDie() {
   std::filesystem::path path = GetOrbitAppDataDir();
   CreateDirectoryOrDie(path);
   return path;
+}
+
+std::filesystem::path CreateOrGetOrbitAppDataDirUnsafe() {
+  return CreateOrGetOrbitAppDataDirOrDie();
 }
 
 ErrorMessageOr<std::filesystem::path> CreateOrGetOrbitAppDataDir() {
@@ -197,10 +207,14 @@ static std::filesystem::path GetDocumentsPath() {
 #endif
 }
 
-std::filesystem::path CreateOrGetOrbitUserDataDirUnsafe() {
+static std::filesystem::path CreateOrGetOrbitUserDataDirOrDie() {
   std::filesystem::path path = GetDocumentsPath() / kOrbitFolderInDocumentsName;
   CreateDirectoryOrDie(path);
   return path;
+}
+
+std::filesystem::path CreateOrGetOrbitUserDataDirUnsafe() {
+  return CreateOrGetOrbitUserDataDirOrDie();
 }
 
 ErrorMessageOr<std::filesystem::path> CreateOrGetOrbitUserDataDir() {
@@ -217,12 +231,14 @@ static std::optional<std::filesystem::path> GetLogDirFromFlag() {
   return std::nullopt;
 }
 
-std::filesystem::path CreateOrGetLogDirUnsafe() {
+static std::filesystem::path CreateOrGetLogDirOrDie() {
   std::filesystem::path logs_dir =
-      GetLogDirFromFlag().value_or(CreateOrGetOrbitAppDataDirUnsafe() / kLogsFolderName);
+      GetLogDirFromFlag().value_or(CreateOrGetOrbitAppDataDirOrDie() / kLogsFolderName);
   CreateDirectoryOrDie(logs_dir);
   return logs_dir;
 }
+
+std::filesystem::path CreateOrGetLogDirUnsafe() { return CreateOrGetLogDirOrDie(); }
 
 ErrorMessageOr<std::filesystem::path> CreateOrGetLogDir() {
   OUTCOME_TRY(std::filesystem::path app_data_dir, CreateOrGetOrbitAppDataDir());
@@ -232,7 +248,7 @@ ErrorMessageOr<std::filesystem::path> CreateOrGetLogDir() {
 }
 
 std::filesystem::path GetLogFilePathUnsafe() {
-  return CreateOrGetLogDirUnsafe() / orbit_base::GetLogFileName();
+  return CreateOrGetLogDirOrDie() / orbit_base::GetLogFileName();
 }
 
 ErrorMessageOr<std::filesystem::path> GetLogFilePath() {

--- a/src/OrbitPaths/PathsTest.cpp
+++ b/src/OrbitPaths/PathsTest.cpp
@@ -16,6 +16,15 @@
 
 namespace orbit_paths {
 
+// The Unsafe variants are deprecated, but as long as they exist they need to be covered by tests.
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif  // __GNUC__
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif  // _MSC_VER
 TEST(Path, AllAutoCreatedDirsExistUnsafe) {
   auto test_fns = {CreateOrGetOrbitAppDataDirUnsafe, CreateOrGetDumpDirUnsafe,
                    CreateOrGetPresetDirUnsafe,       CreateOrGetCacheDirUnsafe,
@@ -54,6 +63,13 @@ TEST(Paths, AllDirsOfFilesExistUnsafe) {
     EXPECT_TRUE(std::filesystem::is_directory(path));
   }
 }
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif  // __GNUC__
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif  // _MSC_VER
 
 TEST(Paths, AllDirsOfFilesExist) {
   auto test_fns = {GetLogFilePath, GetSymbolsFilePath};

--- a/src/OrbitQt/TrackTypeItemModelTest.cpp
+++ b/src/OrbitQt/TrackTypeItemModelTest.cpp
@@ -96,7 +96,7 @@ TEST_F(TrackTypeItemModelTest, ViewInteraction) {
   int x =
       table.columnViewportPosition(static_cast<int>(TrackTypeItemModel::Column::kVisibility)) + 15;
   int y = table.rowViewportPosition(found_row) + 20;
-  QTest::mouseClick(table.viewport(), Qt::MouseButton::LeftButton, {0}, QPoint(x, y));
+  QTest::mouseClick(table.viewport(), Qt::MouseButton::LeftButton, Qt::NoModifier, QPoint(x, y));
   EXPECT_FALSE(track_manager_.GetTrackTypeVisibility(Track::Type::kThreadTrack));
 }
 

--- a/src/OrbitQt/orbitglwidget.cpp
+++ b/src/OrbitQt/orbitglwidget.cpp
@@ -11,6 +11,8 @@
 #include <QOpenGLContext>
 #include <QOpenGLFunctions>
 #include <QPainter>
+#include <QPoint>
+#include <QPointF>
 #include <QRect>
 #include <QSurfaceFormat>
 #include <Qt>
@@ -181,12 +183,15 @@ void OrbitGLWidget::keyReleaseEvent(QKeyEvent* event) {
 
 void OrbitGLWidget::wheelEvent(QWheelEvent* event) {
   if (gl_canvas_) {
-    if (event->orientation() == Qt::Vertical) {
-      gl_canvas_->MouseWheelMoved(event->x(), event->y(), event->delta() / 8,
-                                  (event->modifiers() & Qt::ControlModifier) != 0u);
-    } else {
-      gl_canvas_->MouseWheelMovedHorizontally(event->x(), event->y(), event->delta() / 8,
-                                              (event->modifiers() & Qt::ControlModifier) != 0u);
+    const QPoint angle_delta = event->angleDelta();
+    const QPointF position = event->position();
+    const int x = static_cast<int>(position.x());
+    const int y = static_cast<int>(position.y());
+    const bool ctrl = (event->modifiers() & Qt::ControlModifier) != 0u;
+    if (angle_delta.y() != 0) {
+      gl_canvas_->MouseWheelMoved(x, y, angle_delta.y() / 8, ctrl);
+    } else if (angle_delta.x() != 0) {
+      gl_canvas_->MouseWheelMovedHorizontally(x, y, angle_delta.x() / 8, ctrl);
     }
   }
 

--- a/src/OrbitQt/orbitmainwindow.cpp
+++ b/src/OrbitQt/orbitmainwindow.cpp
@@ -903,8 +903,15 @@ void OrbitMainWindow::on_actionReport_Bug_triggered() {
 }
 
 void OrbitMainWindow::on_actionOpenUserDataDirectory_triggered() {
-  std::string user_data_dir = orbit_paths::CreateOrGetOrbitUserDataDirUnsafe().string();
-  QUrl user_data_url = QUrl::fromLocalFile(QString::fromStdString(user_data_dir));
+  ErrorMessageOr<std::filesystem::path> user_data_dir_or_error =
+      orbit_paths::CreateOrGetOrbitUserDataDir();
+  if (user_data_dir_or_error.has_error()) {
+    QMessageBox::critical(this, "Error opening directory",
+                          QString::fromStdString(user_data_dir_or_error.error().message()));
+    return;
+  }
+  QUrl user_data_url =
+      QUrl::fromLocalFile(QString::fromStdString(user_data_dir_or_error.value().string()));
   if (!QDesktopServices::openUrl(user_data_url)) {
     QMessageBox::critical(this, "Error opening directory",
                           "Could not open Orbit user data directory");
@@ -912,8 +919,15 @@ void OrbitMainWindow::on_actionOpenUserDataDirectory_triggered() {
 }
 
 void OrbitMainWindow::on_actionOpenAppDataDirectory_triggered() {
-  std::string app_data_dir = orbit_paths::CreateOrGetOrbitAppDataDirUnsafe().string();
-  QUrl app_data_url = QUrl::fromLocalFile(QString::fromStdString(app_data_dir));
+  ErrorMessageOr<std::filesystem::path> app_data_dir_or_error =
+      orbit_paths::CreateOrGetOrbitAppDataDir();
+  if (app_data_dir_or_error.has_error()) {
+    QMessageBox::critical(this, "Error opening directory",
+                          QString::fromStdString(app_data_dir_or_error.error().message()));
+    return;
+  }
+  QUrl app_data_url =
+      QUrl::fromLocalFile(QString::fromStdString(app_data_dir_or_error.value().string()));
   if (!QDesktopServices::openUrl(app_data_url)) {
     QMessageBox::critical(this, "Error opening directory",
                           "Could not open Orbit app data directory");
@@ -988,10 +1002,20 @@ void OrbitMainWindow::OnFilterTracksTextChanged(const QString& text) {
   app_->FilterTracks(text.toStdString());
 }
 
+// Returns the directory the preset file dialogs start in, or an empty string -- which makes the
+// dialog fall back to the current directory -- if it cannot be created.
+[[nodiscard]] static QString GetPresetDirAsQString() {
+  ErrorMessageOr<std::filesystem::path> preset_dir_or_error = orbit_paths::CreateOrGetPresetDir();
+  if (preset_dir_or_error.has_error()) {
+    ORBIT_ERROR("Unable to create the preset directory: %s", preset_dir_or_error.error().message());
+    return {};
+  }
+  return QString::fromStdString(preset_dir_or_error.value().string());
+}
+
 void OrbitMainWindow::on_actionOpen_Preset_triggered() {
-  QStringList list = QFileDialog::getOpenFileNames(
-      this, "Select a file to open...",
-      QString::fromStdString(orbit_paths::CreateOrGetPresetDirUnsafe().string()), "*.opr");
+  QStringList list = QFileDialog::getOpenFileNames(this, "Select a file to open...",
+                                                   GetPresetDirAsQString(), "*.opr");
   for (const auto& file : list) {
     ErrorMessageOr<void> result = app_->OnLoadPreset(file.toStdString());
     if (result.has_error()) {
@@ -1005,9 +1029,8 @@ void OrbitMainWindow::on_actionOpen_Preset_triggered() {
 }
 
 void OrbitMainWindow::on_actionSave_Preset_As_triggered() {
-  QString file = QFileDialog::getSaveFileName(
-      this, "Specify a file to save...",
-      QString::fromStdString(orbit_paths::CreateOrGetPresetDirUnsafe().string()), "*.opr");
+  QString file = QFileDialog::getSaveFileName(this, "Specify a file to save...",
+                                              GetPresetDirAsQString(), "*.opr");
   if (file.isEmpty()) {
     return;
   }

--- a/src/OrbitTriggerCaptureVulkanLayer/OrbitCaptureClientLayer.cpp
+++ b/src/OrbitTriggerCaptureVulkanLayer/OrbitCaptureClientLayer.cpp
@@ -70,7 +70,7 @@ OrbitCaptureClientCreateInstance(const VkInstanceCreateInfo* instance_create_inf
   VkResult result = create_instance(instance_create_info, allocator, instance);
 
   {
-    absl::WriterMutexLock lock(&layer_mutex);
+    absl::WriterMutexLock lock(layer_mutex);
     dispatch_table.CreateInstanceDispatchTable(*instance, get_instance_proc_addr);
     // Making the initializations needed for the layer here because vKCreateInstance is called at
     // the start of the dispatch chain.
@@ -83,7 +83,7 @@ OrbitCaptureClientCreateInstance(const VkInstanceCreateInfo* instance_create_inf
 void VKAPI_CALL OrbitCaptureClientDestroyInstance(VkInstance instance,
                                                   const VkAllocationCallbacks* /*allocator*/) {
   ORBIT_LOG("OrbitCaptureClientDestroyInstance called");
-  absl::WriterMutexLock lock(&layer_mutex);
+  absl::WriterMutexLock lock(layer_mutex);
   // Cleaning up the data initialized in the layer before the instance is destroyed. This method is
   // expected to be called before exiting the program so the data is not longer needed.
   layer_logic.Destroy();
@@ -119,7 +119,7 @@ VkResult VKAPI_CALL OrbitCaptureClientCreateDevice(VkPhysicalDevice physical_dev
   VkResult result = create_device(physical_device, device_create_info, allocator, device);
 
   {
-    absl::WriterMutexLock lock(&layer_mutex);
+    absl::WriterMutexLock lock(layer_mutex);
     dispatch_table.CreateDeviceDispatchTable(*device, get_device_proc_addr);
   }
 
@@ -128,7 +128,7 @@ VkResult VKAPI_CALL OrbitCaptureClientCreateDevice(VkPhysicalDevice physical_dev
 
 void VKAPI_CALL OrbitCaptureClientDestroyDevice(VkDevice device,
                                                 const VkAllocationCallbacks* /*allocator*/) {
-  absl::WriterMutexLock lock(&layer_mutex);
+  absl::WriterMutexLock lock(layer_mutex);
   dispatch_table.DestroyDevice(device);
 }
 
@@ -138,7 +138,7 @@ void VKAPI_CALL OrbitCaptureClientDestroyDevice(VkDevice device,
 
 VkResult VKAPI_CALL OrbitCaptureClientQueuePresentKHR(VkQueue queue,
                                                       const VkPresentInfoKHR* present_info) {
-  absl::WriterMutexLock lock(&layer_mutex);
+  absl::WriterMutexLock lock(layer_mutex);
   layer_logic.ProcessQueuePresentKHR();
   return dispatch_table.CallQueuePresentKHR(queue, present_info);
 }
@@ -188,7 +188,7 @@ VkResult VKAPI_CALL OrbitCaptureClientEnumerateDeviceExtensionProperties(
     if (physical_device == VK_NULL_HANDLE) {
       return VK_SUCCESS;
     }
-    absl::ReaderMutexLock lock(&layer_mutex);
+    absl::ReaderMutexLock lock(layer_mutex);
     return dispatch_table.CallEnumerateDeviceExtensionProperties(physical_device, layer_name,
                                                                  property_count, properties);
   }
@@ -217,7 +217,7 @@ OrbitCaptureClientGetDeviceProcAddr(VkDevice device, const char* name) {
   GETPROCADDR(DestroyDevice);
   GETPROCADDR(QueuePresentKHR);
 
-  absl::ReaderMutexLock lock(&layer_mutex);
+  absl::ReaderMutexLock lock(layer_mutex);
   return dispatch_table.CallGetDeviceProcAddr(device, name);
 }
 
@@ -238,6 +238,6 @@ OrbitCaptureClientGetInstanceProcAddr(VkInstance instance, const char* name) {
   GETPROCADDR(DestroyDevice);
   GETPROCADDR(QueuePresentKHR);
 
-  absl::ReaderMutexLock lock(&layer_mutex);
+  absl::ReaderMutexLock lock(layer_mutex);
   return dispatch_table.CallGetInstanceProcAddr(instance, name);
 }

--- a/src/OrbitVulkanLayer/DeviceManager.h
+++ b/src/OrbitVulkanLayer/DeviceManager.h
@@ -34,7 +34,7 @@ class DeviceManager {
   explicit DeviceManager(DispatchTable* dispatch_table) : dispatch_table_(dispatch_table) {}
 
   void TrackLogicalDevice(VkPhysicalDevice physical_device, VkDevice logical_device) {
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
     ORBIT_CHECK(!logical_device_to_physical_device_.contains(logical_device));
     logical_device_to_physical_device_[logical_device] = physical_device;
 
@@ -56,13 +56,13 @@ class DeviceManager {
   }
 
   [[nodiscard]] VkPhysicalDevice GetPhysicalDeviceOfLogicalDevice(VkDevice logical_device) {
-    absl::ReaderMutexLock lock(&mutex_);
+    absl::ReaderMutexLock lock(mutex_);
     ORBIT_CHECK(logical_device_to_physical_device_.contains(logical_device));
     return logical_device_to_physical_device_.at(logical_device);
   }
 
   void UntrackLogicalDevice(VkDevice logical_device) {
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
     ORBIT_CHECK(logical_device_to_physical_device_.contains(logical_device));
     VkPhysicalDevice physical_device = logical_device_to_physical_device_.at(logical_device);
     logical_device_to_physical_device_.erase(logical_device);
@@ -82,7 +82,7 @@ class DeviceManager {
 
   [[nodiscard]] VkPhysicalDeviceProperties GetPhysicalDeviceProperties(
       VkPhysicalDevice physical_device) {
-    absl::ReaderMutexLock lock(&mutex_);
+    absl::ReaderMutexLock lock(mutex_);
     ORBIT_CHECK(physical_device_to_properties_.contains(physical_device));
     return physical_device_to_properties_.at(physical_device);
   }

--- a/src/OrbitVulkanLayer/DispatchTable.cpp
+++ b/src/OrbitVulkanLayer/DispatchTable.cpp
@@ -39,7 +39,7 @@ void DispatchTable::CreateInstanceDispatchTable(
 
   void* key = GetDispatchTableKey(instance);
   {
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
     ORBIT_CHECK(!instance_dispatch_table_.contains(key));
     instance_dispatch_table_[key] = dispatch_table;
 
@@ -63,7 +63,7 @@ void DispatchTable::CreateInstanceDispatchTable(
 void DispatchTable::RemoveInstanceDispatchTable(VkInstance instance) {
   void* key = GetDispatchTableKey(instance);
   {
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
     ORBIT_CHECK(instance_dispatch_table_.contains(key));
     instance_dispatch_table_.erase(key);
 
@@ -156,7 +156,7 @@ void DispatchTable::CreateDeviceDispatchTable(
 
   void* key = GetDispatchTableKey(device);
   {
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
     ORBIT_CHECK(!device_dispatch_table_.contains(key));
     device_dispatch_table_[key] = dispatch_table;
 
@@ -184,7 +184,7 @@ void DispatchTable::CreateDeviceDispatchTable(
 void DispatchTable::RemoveDeviceDispatchTable(VkDevice device) {
   void* key = GetDispatchTableKey(device);
   {
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
 
     ORBIT_CHECK(device_dispatch_table_.contains(key));
     device_dispatch_table_.erase(key);

--- a/src/OrbitVulkanLayer/DispatchTable.h
+++ b/src/OrbitVulkanLayer/DispatchTable.h
@@ -48,7 +48,7 @@ class DispatchTable {
   PFN_vkDestroyDevice DestroyDevice(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).DestroyDevice != nullptr);
       return device_dispatch_table_.at(key).DestroyDevice;
@@ -59,7 +59,7 @@ class DispatchTable {
   PFN_vkDestroyInstance DestroyInstance(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(instance_dispatch_table_.contains(key));
       ORBIT_CHECK(instance_dispatch_table_.at(key).DestroyInstance != nullptr);
       return instance_dispatch_table_.at(key).DestroyInstance;
@@ -71,7 +71,7 @@ class DispatchTable {
       DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(instance_dispatch_table_.contains(key));
       ORBIT_CHECK(instance_dispatch_table_.at(key).EnumerateDeviceExtensionProperties != nullptr);
       return instance_dispatch_table_.at(key).EnumerateDeviceExtensionProperties;
@@ -83,7 +83,7 @@ class DispatchTable {
       DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(instance_dispatch_table_.contains(key));
       ORBIT_CHECK(instance_dispatch_table_.at(key).GetPhysicalDeviceProperties != nullptr);
       return instance_dispatch_table_.at(key).GetPhysicalDeviceProperties;
@@ -94,7 +94,7 @@ class DispatchTable {
   PFN_vkGetInstanceProcAddr GetInstanceProcAddr(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(instance_dispatch_table_.contains(key));
       ORBIT_CHECK(instance_dispatch_table_.at(key).GetInstanceProcAddr != nullptr);
       return instance_dispatch_table_.at(key).GetInstanceProcAddr;
@@ -105,7 +105,7 @@ class DispatchTable {
   PFN_vkGetDeviceProcAddr GetDeviceProcAddr(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).GetDeviceProcAddr != nullptr);
       return device_dispatch_table_.at(key).GetDeviceProcAddr;
@@ -116,7 +116,7 @@ class DispatchTable {
   PFN_vkResetCommandPool ResetCommandPool(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).ResetCommandPool != nullptr);
       return device_dispatch_table_.at(key).ResetCommandPool;
@@ -127,7 +127,7 @@ class DispatchTable {
   PFN_vkAllocateCommandBuffers AllocateCommandBuffers(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).AllocateCommandBuffers != nullptr);
       return device_dispatch_table_.at(key).AllocateCommandBuffers;
@@ -138,7 +138,7 @@ class DispatchTable {
   PFN_vkFreeCommandBuffers FreeCommandBuffers(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).FreeCommandBuffers != nullptr);
       return device_dispatch_table_.at(key).FreeCommandBuffers;
@@ -149,7 +149,7 @@ class DispatchTable {
   PFN_vkBeginCommandBuffer BeginCommandBuffer(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).BeginCommandBuffer != nullptr);
       return device_dispatch_table_.at(key).BeginCommandBuffer;
@@ -160,7 +160,7 @@ class DispatchTable {
   PFN_vkEndCommandBuffer EndCommandBuffer(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).EndCommandBuffer != nullptr);
       return device_dispatch_table_.at(key).EndCommandBuffer;
@@ -171,7 +171,7 @@ class DispatchTable {
   PFN_vkResetCommandBuffer ResetCommandBuffer(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).ResetCommandBuffer != nullptr);
       return device_dispatch_table_.at(key).ResetCommandBuffer;
@@ -182,7 +182,7 @@ class DispatchTable {
   PFN_vkGetDeviceQueue GetDeviceQueue(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).GetDeviceQueue != nullptr);
       return device_dispatch_table_.at(key).GetDeviceQueue;
@@ -193,7 +193,7 @@ class DispatchTable {
   PFN_vkGetDeviceQueue2 GetDeviceQueue2(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).GetDeviceQueue2 != nullptr);
       return device_dispatch_table_.at(key).GetDeviceQueue2;
@@ -204,7 +204,7 @@ class DispatchTable {
   PFN_vkQueueSubmit QueueSubmit(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).QueueSubmit != nullptr);
       return device_dispatch_table_.at(key).QueueSubmit;
@@ -215,7 +215,7 @@ class DispatchTable {
   PFN_vkQueuePresentKHR QueuePresentKHR(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).QueuePresentKHR != nullptr);
       return device_dispatch_table_.at(key).QueuePresentKHR;
@@ -226,7 +226,7 @@ class DispatchTable {
   PFN_vkCreateQueryPool CreateQueryPool(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).CreateQueryPool != nullptr);
       return device_dispatch_table_.at(key).CreateQueryPool;
@@ -237,7 +237,7 @@ class DispatchTable {
   PFN_vkDestroyQueryPool DestroyQueryPool(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).DestroyQueryPool != nullptr);
       return device_dispatch_table_.at(key).DestroyQueryPool;
@@ -248,7 +248,7 @@ class DispatchTable {
   PFN_vkResetQueryPoolEXT ResetQueryPoolEXT(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).ResetQueryPoolEXT != nullptr);
       return device_dispatch_table_.at(key).ResetQueryPoolEXT;
@@ -259,7 +259,7 @@ class DispatchTable {
   PFN_vkGetQueryPoolResults GetQueryPoolResults(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).GetQueryPoolResults != nullptr);
       return device_dispatch_table_.at(key).GetQueryPoolResults;
@@ -270,7 +270,7 @@ class DispatchTable {
   PFN_vkCmdWriteTimestamp CmdWriteTimestamp(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).CmdWriteTimestamp != nullptr);
       return device_dispatch_table_.at(key).CmdWriteTimestamp;
@@ -284,7 +284,7 @@ class DispatchTable {
   PFN_vkCmdDebugMarkerBeginEXT CmdDebugMarkerBeginEXT(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).CmdDebugMarkerBeginEXT != nullptr);
       return device_dispatch_table_.at(key).CmdDebugMarkerBeginEXT;
@@ -295,7 +295,7 @@ class DispatchTable {
   PFN_vkCmdDebugMarkerEndEXT CmdDebugMarkerEndEXT(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).CmdDebugMarkerEndEXT != nullptr);
       return device_dispatch_table_.at(key).CmdDebugMarkerEndEXT;
@@ -306,7 +306,7 @@ class DispatchTable {
   PFN_vkCmdDebugMarkerInsertEXT CmdDebugMarkerInsertEXT(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).CmdDebugMarkerInsertEXT != nullptr);
       return device_dispatch_table_.at(key).CmdDebugMarkerInsertEXT;
@@ -318,7 +318,7 @@ class DispatchTable {
       DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).DebugMarkerSetObjectTagEXT != nullptr);
       return device_dispatch_table_.at(key).DebugMarkerSetObjectTagEXT;
@@ -330,7 +330,7 @@ class DispatchTable {
       DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).DebugMarkerSetObjectNameEXT != nullptr);
       return device_dispatch_table_.at(key).DebugMarkerSetObjectNameEXT;
@@ -341,7 +341,7 @@ class DispatchTable {
   bool IsDebugMarkerExtensionSupported(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_supports_debug_marker_extension_.contains(key));
       return device_supports_debug_marker_extension_.at(key);
     }
@@ -355,7 +355,7 @@ class DispatchTable {
       DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).CmdBeginDebugUtilsLabelEXT != nullptr);
       return device_dispatch_table_.at(key).CmdBeginDebugUtilsLabelEXT;
@@ -366,7 +366,7 @@ class DispatchTable {
   PFN_vkCmdEndDebugUtilsLabelEXT CmdEndDebugUtilsLabelEXT(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).CmdEndDebugUtilsLabelEXT != nullptr);
       return device_dispatch_table_.at(key).CmdEndDebugUtilsLabelEXT;
@@ -378,7 +378,7 @@ class DispatchTable {
       DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).CmdInsertDebugUtilsLabelEXT != nullptr);
       return device_dispatch_table_.at(key).CmdInsertDebugUtilsLabelEXT;
@@ -390,7 +390,7 @@ class DispatchTable {
       DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).SetDebugUtilsObjectNameEXT != nullptr);
       return device_dispatch_table_.at(key).SetDebugUtilsObjectNameEXT;
@@ -401,7 +401,7 @@ class DispatchTable {
   PFN_vkSetDebugUtilsObjectTagEXT SetDebugUtilsObjectTagEXT(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).SetDebugUtilsObjectTagEXT != nullptr);
       return device_dispatch_table_.at(key).SetDebugUtilsObjectTagEXT;
@@ -413,7 +413,7 @@ class DispatchTable {
       DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).QueueBeginDebugUtilsLabelEXT != nullptr);
       return device_dispatch_table_.at(key).QueueBeginDebugUtilsLabelEXT;
@@ -425,7 +425,7 @@ class DispatchTable {
       DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).QueueEndDebugUtilsLabelEXT != nullptr);
       return device_dispatch_table_.at(key).QueueEndDebugUtilsLabelEXT;
@@ -437,7 +437,7 @@ class DispatchTable {
       DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_dispatch_table_.contains(key));
       ORBIT_CHECK(device_dispatch_table_.at(key).QueueInsertDebugUtilsLabelEXT != nullptr);
       return device_dispatch_table_.at(key).QueueInsertDebugUtilsLabelEXT;
@@ -449,7 +449,7 @@ class DispatchTable {
       DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(instance_dispatch_table_.contains(key));
       ORBIT_CHECK(instance_dispatch_table_.at(key).CreateDebugUtilsMessengerEXT != nullptr);
       return instance_dispatch_table_.at(key).CreateDebugUtilsMessengerEXT;
@@ -461,7 +461,7 @@ class DispatchTable {
       DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(instance_dispatch_table_.contains(key));
       ORBIT_CHECK(instance_dispatch_table_.at(key).DestroyDebugUtilsMessengerEXT != nullptr);
       return instance_dispatch_table_.at(key).DestroyDebugUtilsMessengerEXT;
@@ -473,7 +473,7 @@ class DispatchTable {
       DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(instance_dispatch_table_.contains(key));
       ORBIT_CHECK(instance_dispatch_table_.at(key).SubmitDebugUtilsMessageEXT != nullptr);
       return instance_dispatch_table_.at(key).SubmitDebugUtilsMessageEXT;
@@ -484,7 +484,7 @@ class DispatchTable {
   bool IsDebugUtilsExtensionSupported(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(device_supports_debug_utils_extension_.contains(key));
       return device_supports_debug_utils_extension_.at(key);
     }
@@ -493,7 +493,7 @@ class DispatchTable {
   bool IsDebugUtilsExtensionSupported(VkInstance instance) {
     void* key = GetDispatchTableKey(instance);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(instance_supports_debug_utils_extension_.contains(key));
       return instance_supports_debug_utils_extension_.at(key);
     }
@@ -507,7 +507,7 @@ class DispatchTable {
       DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(instance_dispatch_table_.contains(key));
       ORBIT_CHECK(instance_dispatch_table_.at(key).CreateDebugReportCallbackEXT != nullptr);
       return instance_dispatch_table_.at(key).CreateDebugReportCallbackEXT;
@@ -519,7 +519,7 @@ class DispatchTable {
       DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(instance_dispatch_table_.contains(key));
       ORBIT_CHECK(instance_dispatch_table_.at(key).DestroyDebugReportCallbackEXT != nullptr);
       return instance_dispatch_table_.at(key).DestroyDebugReportCallbackEXT;
@@ -530,7 +530,7 @@ class DispatchTable {
   PFN_vkDebugReportMessageEXT DebugReportMessageEXT(DispatchableType dispatchable_object) {
     void* key = GetDispatchTableKey(dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(instance_dispatch_table_.contains(key));
       ORBIT_CHECK(instance_dispatch_table_.at(key).DebugReportMessageEXT != nullptr);
       return instance_dispatch_table_.at(key).DebugReportMessageEXT;
@@ -540,7 +540,7 @@ class DispatchTable {
   bool IsDebugReportExtensionSupported(VkInstance instance) {
     void* key = GetDispatchTableKey(instance);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(instance_supports_debug_report_extension_.contains(key));
       return instance_supports_debug_report_extension_.at(key);
     }
@@ -550,7 +550,7 @@ class DispatchTable {
   VkInstance GetInstance(DispatchableType instance_dispatchable_object) {
     void* key = GetDispatchTableKey(instance_dispatchable_object);
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       ORBIT_CHECK(instance_dispatchable_object_to_instance_.contains(key));
       return instance_dispatchable_object_to_instance_.at(key);
     }

--- a/src/OrbitVulkanLayer/QueueManager.cpp
+++ b/src/OrbitVulkanLayer/QueueManager.cpp
@@ -9,13 +9,13 @@
 namespace orbit_vulkan_layer {
 
 void QueueManager::TrackQueue(VkQueue queue, VkDevice device) {
-  absl::WriterMutexLock lock(&mutex_);
+  absl::WriterMutexLock lock(mutex_);
   ORBIT_CHECK(!queue_to_device_.contains(queue) || queue_to_device_.at(queue) == device);
   queue_to_device_.emplace(queue, device);
 }
 
 VkDevice QueueManager::GetDeviceOfQueue(VkQueue queue) {
-  absl::ReaderMutexLock lock(&mutex_);
+  absl::ReaderMutexLock lock(mutex_);
   ORBIT_CHECK(queue_to_device_.contains(queue));
   return queue_to_device_.at(queue);
 }

--- a/src/OrbitVulkanLayer/SubmissionTracker.h
+++ b/src/OrbitVulkanLayer/SubmissionTracker.h
@@ -167,7 +167,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
 
   void TrackCommandBuffers(VkDevice device, VkCommandPool pool,
                            const VkCommandBuffer* command_buffers, uint32_t count) {
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
     auto associated_cbs_it = pool_to_command_buffers_.find(pool);
     if (associated_cbs_it == pool_to_command_buffers_.end()) {
       associated_cbs_it = pool_to_command_buffers_.try_emplace(pool).first;
@@ -181,7 +181,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
 
   void UntrackCommandBuffers(VkDevice device, VkCommandPool pool,
                              const VkCommandBuffer* command_buffers, uint32_t count) {
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
     ORBIT_CHECK(pool_to_command_buffers_.contains(pool));
     absl::flat_hash_set<VkCommandBuffer>& associated_command_buffers =
         pool_to_command_buffers_.at(pool);
@@ -213,7 +213,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
   }
 
   void MarkCommandBufferBegin(VkCommandBuffer command_buffer) {
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
     // Even when we are not capturing we create state for this command buffer to allow the
     // debug marker tracking. In order to compute the correct depth of a debug marker and being able
     // to match an "end" marker with the corresponding "begin" marker, we maintain a stack of all
@@ -245,7 +245,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
   }
 
   void MarkCommandBufferEnd(VkCommandBuffer command_buffer) {
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
     if (!is_capturing_) {
       return;
     }
@@ -267,7 +267,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
   }
 
   void MarkDebugMarkerBegin(VkCommandBuffer command_buffer, const char* text, Color color) {
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
     // It is ensured by the Vulkan spec. that `text` must not be nullptr.
     ORBIT_CHECK(text != nullptr);
     bool marker_depth_exceeds_maximum = false;
@@ -304,7 +304,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
   }
 
   void MarkDebugMarkerEnd(VkCommandBuffer command_buffer) {
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
 
     if (!command_buffer_to_state_.contains(command_buffer)) {
       ORBIT_ERROR_ONCE(
@@ -348,7 +348,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
   // This allows us to map submissions from the Vulkan layer to the driver submissions.
   [[nodiscard]] std::optional<QueueSubmission> PersistCommandBuffersOnSubmit(
       VkQueue queue, uint32_t submit_count, const VkSubmitInfo* submits) {
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
     if (!is_capturing_) {
       // `OnCaptureFinished` has already been called and has taken care of resetting slots.
       return std::nullopt;
@@ -405,7 +405,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
   void PersistDebugMarkersOnSubmit(VkQueue queue, uint32_t submit_count,
                                    const VkSubmitInfo* submits,
                                    std::optional<QueueSubmission> queue_submission_optional) {
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
     if (!queue_to_markers_.contains(queue)) {
       queue_to_markers_[queue] = {};
     }
@@ -468,7 +468,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
   // This method also resets all the timer slots that have been read.
   // It is assumed to be called periodically, e.g. on `vkQueuePresentKHR`.
   void CompleteSubmits(VkDevice device) {
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
     VkQueryPool query_pool = timer_query_pool_->GetQueryPool(device);
 
     if (queue_to_submission_priority_queue_.empty()) {
@@ -532,14 +532,14 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
   }
 
   void ResetCommandBuffer(VkCommandBuffer command_buffer) {
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
     ResetCommandBufferUnsafe(command_buffer);
   }
 
   void ResetCommandPool(VkCommandPool command_pool) {
     absl::flat_hash_set<VkCommandBuffer> command_buffers;
     {
-      absl::ReaderMutexLock lock(&mutex_);
+      absl::ReaderMutexLock lock(mutex_);
       if (!pool_to_command_buffers_.contains(command_pool)) {
         return;
       }
@@ -552,7 +552,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
   }
 
   void OnCaptureStart(orbit_grpc_protos::CaptureOptions capture_options) override {
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
     SetMaxLocalMarkerDepthPerCommandBuffer(
         capture_options.max_local_marker_depth_per_command_buffer());
     is_capturing_ = true;
@@ -561,7 +561,7 @@ class SubmissionTracker : public VulkanLayerProducer::CaptureStatusListener {
   void OnCaptureStop() override {}
 
   void OnCaptureFinished() override {
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
     std::vector<uint32_t> slots_not_needed_to_read_anymore;
 
     VkDevice device = VK_NULL_HANDLE;

--- a/src/OrbitVulkanLayer/TimerQueryPool.h
+++ b/src/OrbitVulkanLayer/TimerQueryPool.h
@@ -77,7 +77,7 @@ class TimerQueryPool {
     dispatch_table_->ResetQueryPoolEXT(device)(device, query_pool, 0, num_timer_query_slots_);
 
     {
-      absl::WriterMutexLock lock(&mutex_);
+      absl::WriterMutexLock lock(mutex_);
       ORBIT_CHECK(!device_to_query_pool_.contains(device));
       device_to_query_pool_[device] = query_pool;
       std::vector<SlotState> slots{num_timer_query_slots_};
@@ -92,7 +92,7 @@ class TimerQueryPool {
 
   // Destroys the VkQueryPool for the given device
   void DestroyTimerQueryPool(VkDevice device) {
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
     ORBIT_CHECK(device_to_query_pool_.contains(device));
     VkQueryPool query_pool = device_to_query_pool_.at(device);
     device_to_query_slots_.erase(device);
@@ -106,7 +106,7 @@ class TimerQueryPool {
   // Retrieves the query pool for a given device. Note that the pool must be initialized using
   // `InitializeTimerQueryPool` before.
   [[nodiscard]] VkQueryPool GetQueryPool(VkDevice device) {
-    absl::ReaderMutexLock lock(&mutex_);
+    absl::ReaderMutexLock lock(mutex_);
     ORBIT_CHECK(device_to_query_pool_.contains(device));
     return device_to_query_pool_.at(device);
   }
@@ -118,7 +118,7 @@ class TimerQueryPool {
   // Note that the pool must be initialized using `InitializeTimerQueryPool` before.
   // See also `ResetQuerySlots` to make occupied slots available again.
   [[nodiscard]] bool NextReadyQuerySlot(VkDevice device, uint32_t* allocated_index) {
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
     ORBIT_CHECK(device_to_free_slots_.contains(device));
     ORBIT_CHECK(device_to_query_slots_.contains(device));
     std::vector<uint32_t>& free_slots = device_to_free_slots_.at(device);
@@ -149,7 +149,7 @@ class TimerQueryPool {
     if (slot_indices.empty()) {
       return;
     }
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
     ORBIT_CHECK(device_to_query_slots_.contains(device));
     std::vector<SlotState>& slot_states = device_to_query_slots_.at(device);
     ORBIT_CHECK(device_to_free_slots_.contains(device));
@@ -184,7 +184,7 @@ class TimerQueryPool {
     if (slot_indices.empty()) {
       return;
     }
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
     ORBIT_CHECK(device_to_query_slots_.contains(device));
     std::vector<SlotState>& slot_states = device_to_query_slots_.at(device);
     ORBIT_CHECK(device_to_free_slots_.contains(device));
@@ -216,7 +216,7 @@ class TimerQueryPool {
     if (slot_indices.empty()) {
       return;
     }
-    absl::WriterMutexLock lock(&mutex_);
+    absl::WriterMutexLock lock(mutex_);
     ORBIT_CHECK(device_to_query_slots_.contains(device));
     std::vector<SlotState>& slot_states = device_to_query_slots_.at(device);
     ORBIT_CHECK(device_to_free_slots_.contains(device));

--- a/src/OrbitVulkanLayer/VulkanLayerController.h
+++ b/src/OrbitVulkanLayer/VulkanLayerController.h
@@ -627,7 +627,7 @@ class VulkanLayerController {
 
  private:
   void InitVulkanLayerProducerIfNecessary() {
-    absl::MutexLock lock{&vulkan_layer_producer_mutex_};
+    absl::MutexLock lock{vulkan_layer_producer_mutex_};
     if (vulkan_layer_producer_ == nullptr) {
       vulkan_layer_producer_ = std::make_unique<VulkanLayerProducerImpl>();
       ORBIT_LOG("Bringing up VulkanLayerProducer");
@@ -653,7 +653,7 @@ class VulkanLayerController {
   }
 
   void CloseVulkanLayerProducerIfNecessary() {
-    absl::MutexLock lock{&vulkan_layer_producer_mutex_};
+    absl::MutexLock lock{vulkan_layer_producer_mutex_};
     if (vulkan_layer_producer_ != nullptr) {
       // TODO: Only do this when DestroyInstance has been called the same number of times as
       //  CreateInstance.

--- a/src/OrbitVulkanLayer/VulkanLayerProducerImpl.cpp
+++ b/src/OrbitVulkanLayer/VulkanLayerProducerImpl.cpp
@@ -9,7 +9,7 @@ namespace orbit_vulkan_layer {
 uint64_t VulkanLayerProducerImpl::InternStringIfNecessaryAndGetKey(std::string str) {
   uint64_t key = ComputeStringKey(str);
   {
-    absl::MutexLock lock{&string_keys_sent_mutex_};
+    absl::MutexLock lock{string_keys_sent_mutex_};
     bool inserted = string_keys_sent_.emplace(key).second;
     if (!inserted) {
       return key;

--- a/src/OrbitVulkanLayer/VulkanLayerProducerImpl.h
+++ b/src/OrbitVulkanLayer/VulkanLayerProducerImpl.h
@@ -100,7 +100,7 @@ class VulkanLayerProducerImpl : public VulkanLayerProducer {
   }
 
   void ClearStringInternPool() {
-    absl::MutexLock lock{&string_keys_sent_mutex_};
+    absl::MutexLock lock{string_keys_sent_mutex_};
     string_keys_sent_.clear();
   }
 

--- a/src/OrbitVulkanLayer/VulkanLayerProducerImplTest.cpp
+++ b/src/OrbitVulkanLayer/VulkanLayerProducerImplTest.cpp
@@ -275,7 +275,7 @@ TEST_F(VulkanLayerProducerImplTest, InternStringIfNecessaryAndGetKey) {
       .Times(::testing::Between(1, 2))
       .WillRepeatedly([&events_received, &events_received_mutex](
                           absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events) {
-        absl::MutexLock lock{&events_received_mutex};
+        absl::MutexLock lock{events_received_mutex};
         events_received.insert(events_received.end(), events.begin(), events.end());
       });
   EXPECT_CALL(*fake_service_, OnAllEventsSentReceived).Times(0);
@@ -293,7 +293,7 @@ TEST_F(VulkanLayerProducerImplTest, InternStringIfNecessaryAndGetKey) {
   EXPECT_EQ(actual_key, kExpectedInternedString2Key);
   std::this_thread::sleep_for(kWaitMessagesSentDuration);
   {
-    absl::MutexLock lock{&events_received_mutex};
+    absl::MutexLock lock{events_received_mutex};
     ExpectInternedStrings(events_received, {{kInternedString1, kExpectedInternedString1Key},
                                             {kInternedString2, kExpectedInternedString2Key}});
   }
@@ -343,7 +343,7 @@ TEST_F(VulkanLayerProducerImplTest, DontSendInternTwice) {
       .Times(1)
       .WillRepeatedly([&events_received, &events_received_mutex](
                           absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events) {
-        absl::MutexLock lock{&events_received_mutex};
+        absl::MutexLock lock{events_received_mutex};
         events_received.insert(events_received.end(), events.begin(), events.end());
       });
   EXPECT_CALL(*fake_service_, OnAllEventsSentReceived).Times(0);
@@ -354,7 +354,7 @@ TEST_F(VulkanLayerProducerImplTest, DontSendInternTwice) {
   EXPECT_EQ(actual_key, kExpectedInternedString1Key);
   std::this_thread::sleep_for(kWaitMessagesSentDuration);
   {
-    absl::MutexLock lock{&events_received_mutex};
+    absl::MutexLock lock{events_received_mutex};
     ExpectInternedStrings(events_received, {{kInternedString1, kExpectedInternedString1Key}});
   }
 
@@ -391,7 +391,7 @@ TEST_F(VulkanLayerProducerImplTest, ReInternInNewCapture) {
       .Times(::testing::Between(1, 2))
       .WillRepeatedly([&events_received, &events_received_mutex](
                           absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events) {
-        absl::MutexLock lock{&events_received_mutex};
+        absl::MutexLock lock{events_received_mutex};
         events_received.insert(events_received.end(), events.begin(), events.end());
       });
   EXPECT_CALL(*fake_service_, OnAllEventsSentReceived).Times(0);
@@ -401,7 +401,7 @@ TEST_F(VulkanLayerProducerImplTest, ReInternInNewCapture) {
   EXPECT_EQ(actual_key, kExpectedInternedString2Key);
   std::this_thread::sleep_for(kWaitMessagesSentDuration);
   {
-    absl::MutexLock lock{&events_received_mutex};
+    absl::MutexLock lock{events_received_mutex};
     ExpectInternedStrings(events_received, {{kInternedString1, kExpectedInternedString1Key},
                                             {kInternedString2, kExpectedInternedString2Key}});
   }
@@ -437,14 +437,14 @@ TEST_F(VulkanLayerProducerImplTest, ReInternInNewCapture) {
   ::testing::Mock::VerifyAndClearExpectations(&*fake_service_);
 
   {
-    absl::MutexLock lock{&events_received_mutex};
+    absl::MutexLock lock{events_received_mutex};
     events_received.clear();
   }
   EXPECT_CALL(*fake_service_, OnCaptureEventsReceived)
       .Times(::testing::Between(1, 2))
       .WillRepeatedly([&events_received, &events_received_mutex](
                           absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events) {
-        absl::MutexLock lock{&events_received_mutex};
+        absl::MutexLock lock{events_received_mutex};
         events_received.insert(events_received.end(), events.begin(), events.end());
       });
   EXPECT_CALL(*fake_service_, OnAllEventsSentReceived).Times(0);
@@ -454,7 +454,7 @@ TEST_F(VulkanLayerProducerImplTest, ReInternInNewCapture) {
   EXPECT_EQ(actual_key, kExpectedInternedString2Key);
   std::this_thread::sleep_for(kWaitMessagesSentDuration);
   {
-    absl::MutexLock lock{&events_received_mutex};
+    absl::MutexLock lock{events_received_mutex};
     ExpectInternedStrings(events_received, {{kInternedString1, kExpectedInternedString1Key},
                                             {kInternedString2, kExpectedInternedString2Key}});
   }
@@ -532,7 +532,7 @@ TEST_F(VulkanLayerProducerImplTest, InternOnlyWhenCapturing) {
       .Times(::testing::Between(1, 2))
       .WillRepeatedly([&events_received, &events_received_mutex](
                           absl::Span<const orbit_grpc_protos::ProducerCaptureEvent> events) {
-        absl::MutexLock lock{&events_received_mutex};
+        absl::MutexLock lock{events_received_mutex};
         events_received.insert(events_received.end(), events.begin(), events.end());
       });
   EXPECT_CALL(*fake_service_, OnAllEventsSentReceived).Times(0);
@@ -542,7 +542,7 @@ TEST_F(VulkanLayerProducerImplTest, InternOnlyWhenCapturing) {
   EXPECT_EQ(actual_key, kExpectedInternedString2Key);
   std::this_thread::sleep_for(kWaitMessagesSentDuration);
   {
-    absl::MutexLock lock{&events_received_mutex};
+    absl::MutexLock lock{events_received_mutex};
     ExpectInternedStrings(events_received, {{kInternedString1, kExpectedInternedString1Key},
                                             {kInternedString2, kExpectedInternedString2Key}});
   }

--- a/src/ProcessService/ProcessServiceImpl.cpp
+++ b/src/ProcessService/ProcessServiceImpl.cpp
@@ -46,7 +46,7 @@ Status ProcessServiceImpl::GetProcessList(ServerContext* /*context*/,
                                           const GetProcessListRequest* /*request*/,
                                           GetProcessListResponse* response) {
   {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
 
     const auto refresh_result = process_list_.Refresh();
     if (refresh_result.has_error()) {

--- a/src/ProducerEventProcessor/GrpcClientCaptureEventCollector.cpp
+++ b/src/ProducerEventProcessor/GrpcClientCaptureEventCollector.cpp
@@ -50,7 +50,7 @@ GrpcClientCaptureEventCollector::GrpcClientCaptureEventCollector(
 }
 
 void GrpcClientCaptureEventCollector::AddEvent(ClientCaptureEvent&& event) {
-  absl::MutexLock lock{&mutex_};
+  absl::MutexLock lock{mutex_};
   if (stop_requested_) {
     return;
   }
@@ -76,7 +76,7 @@ void GrpcClientCaptureEventCollector::StopAndWait() {
   {
     // Protect stop_requested_ with mutex_ so that we can use stop_requested_ in Conditions for
     // Await/LockWhen (specifically, in SenderThread).
-    absl::MutexLock lock{&mutex_};
+    absl::MutexLock lock{mutex_};
     stop_requested_ = true;
   }
   sender_thread_.join();
@@ -122,7 +122,7 @@ void GrpcClientCaptureEventCollector::SenderThread() {
       stopped = true;
     }
     if (capture_responses_being_built_.empty()) {
-      mutex_.Unlock();
+      mutex_.unlock();
       continue;
     }
 
@@ -130,7 +130,7 @@ void GrpcClientCaptureEventCollector::SenderThread() {
     // `arena_of_capture_response_to_send_` are effectively the two buffers.
     arena_of_capture_responses_being_built_.swap(arena_of_capture_responses_to_send_);
     capture_responses_being_built_.swap(capture_responses_to_send_);
-    mutex_.Unlock();
+    mutex_.unlock();
 
     uint64_t number_of_events_sent = 0;
     uint64_t number_of_bytes_sent = 0;

--- a/src/ProducerEventProcessor/ProducerEventProcessor.cpp
+++ b/src/ProducerEventProcessor/ProducerEventProcessor.cpp
@@ -80,7 +80,7 @@ class InternPool final {
   // Return pair of <id, assigned>, where assigned is true if the entry was assigned a new id
   // and false if returning id for already existing entry.
   std::pair<uint64_t, bool> GetOrAssignId(const T& entry) {
-    absl::MutexLock lock(&entry_to_id_mutex_);
+    absl::MutexLock lock(entry_to_id_mutex_);
     auto it = entry_to_id_.find(entry);
     if (it != entry_to_id_.end()) {
       return std::make_pair(it->second, false);

--- a/src/ProducerEventProcessor/ProducerEventProcessorTest.cpp
+++ b/src/ProducerEventProcessor/ProducerEventProcessorTest.cpp
@@ -81,7 +81,6 @@ using orbit_grpc_protos::WarningInstrumentingWithUserSpaceInstrumentationEvent;
 using google::protobuf::util::MessageDifferencer;
 using ::testing::ElementsAre;
 using ::testing::ElementsAreArray;
-using ::testing::Invoke;
 using ::testing::SaveArg;
 
 namespace orbit_producer_event_processor {
@@ -1468,15 +1467,15 @@ TEST(ProducerEventProcessor, MergingThreadStateSliceWithCallstack) {
   std::optional<uint64_t> actual_callstack_key;
   EXPECT_CALL(collector, AddEvent)
       .Times(3)
-      .WillRepeatedly(Invoke([&actual_client_capture_events,
-                              &actual_callstack_key](ClientCaptureEvent&& client_capture_event) {
+      .WillRepeatedly([&actual_client_capture_events,
+                       &actual_callstack_key](ClientCaptureEvent&& client_capture_event) {
         if (client_capture_event.has_interned_callstack()) {
           // We are only expecting a single interned callstack
           ASSERT_FALSE(actual_callstack_key.has_value());
           actual_callstack_key = client_capture_event.interned_callstack().key();
         }
         actual_client_capture_events.push_back(std::move(client_capture_event));
-      }));
+      });
 
   producer_event_processor->ProcessEvent(orbit_grpc_protos::kLinuxTracingProducerId,
                                          std::move(thread_state_slice_callstack_event1));

--- a/src/ProducerSideService/ProducerSideServiceImpl.cpp
+++ b/src/ProducerSideService/ProducerSideServiceImpl.cpp
@@ -27,11 +27,11 @@ void ProducerSideServiceImpl::OnCaptureStartRequested(
   ORBIT_CHECK(producer_event_processor != nullptr);
   ORBIT_LOG("About to send StartCaptureCommand to CaptureEventProducers (if any)");
   {
-    absl::WriterMutexLock lock{&producer_event_processor_mutex_};
+    absl::WriterMutexLock lock{producer_event_processor_mutex_};
     producer_event_processor_ = producer_event_processor;
   }
   {
-    absl::MutexLock lock{&service_state_mutex_};
+    absl::MutexLock lock{service_state_mutex_};
     service_state_.capture_status = CaptureStatus::kCaptureStarted;
     service_state_.capture_options = std::move(capture_options);
   }
@@ -40,7 +40,7 @@ void ProducerSideServiceImpl::OnCaptureStartRequested(
 void ProducerSideServiceImpl::OnCaptureStopRequested() {
   ORBIT_LOG("About to send StopCaptureCommand to CaptureEventProducers (if any)");
   {
-    absl::MutexLock lock{&service_state_mutex_};
+    absl::MutexLock lock{service_state_mutex_};
     service_state_.capture_status = CaptureStatus::kCaptureStopping;
 
     // Wait (for a limited amount of time) for all producers to send AllEventsSent or to disconnect.
@@ -66,21 +66,21 @@ void ProducerSideServiceImpl::OnCaptureStopRequested() {
   }
 
   {
-    absl::WriterMutexLock lock{&producer_event_processor_mutex_};
+    absl::WriterMutexLock lock{producer_event_processor_mutex_};
     producer_event_processor_ = nullptr;
   }
 }
 
 void ProducerSideServiceImpl::OnExitRequest() {
   {
-    absl::MutexLock lock{&service_state_mutex_};
+    absl::MutexLock lock{service_state_mutex_};
     service_state_.exit_requested = true;
     service_state_.capture_options = std::nullopt;
   }
 
   ORBIT_LOG("Attempting to disconnect from CaptureEventProducers as exit was requested");
   {
-    absl::MutexLock lock{&server_contexts_mutex_};
+    absl::MutexLock lock{server_contexts_mutex_};
     for (grpc::ServerContext* context : server_contexts_) {
       // This should cause blocking Reads on ServerReaderWriter to fail immediately.
       context->TryCancel();
@@ -88,7 +88,7 @@ void ProducerSideServiceImpl::OnExitRequest() {
   }
 
   {
-    absl::WriterMutexLock lock{&producer_event_processor_mutex_};
+    absl::WriterMutexLock lock{producer_event_processor_mutex_};
     producer_event_processor_ = nullptr;
   }
 }
@@ -100,7 +100,7 @@ grpc::Status ProducerSideServiceImpl::ReceiveCommandsAndSendEvents(
   ORBIT_LOG("A CaptureEventProducer has connected calling ReceiveCommandsAndSendEvents");
 
   {
-    absl::MutexLock lock{&server_contexts_mutex_};
+    absl::MutexLock lock{server_contexts_mutex_};
     server_contexts_.emplace(context);
   }
 
@@ -136,7 +136,7 @@ grpc::Status ProducerSideServiceImpl::ReceiveCommandsAndSendEvents(
   send_commands_thread.join();
 
   {
-    absl::MutexLock lock{&server_contexts_mutex_};
+    absl::MutexLock lock{server_contexts_mutex_};
     server_contexts_.erase(context);
   }
 
@@ -222,7 +222,7 @@ void ProducerSideServiceImpl::SendCommandsThread(
     CaptureStatus curr_capture_status;
     std::optional<orbit_grpc_protos::CaptureOptions> curr_capture_options;
     {
-      absl::MutexLock lock{&service_state_mutex_};
+      absl::MutexLock lock{service_state_mutex_};
       if (service_state_.exit_requested) {
         return;
       }
@@ -293,7 +293,7 @@ void ProducerSideServiceImpl::SendCommandsThread(
       }
       curr_capture_status = service_state_.capture_status;
       curr_capture_options = service_state_.capture_options;
-    }  // absl::MutexLock lock{&service_state_mutex_}
+    }  // absl::MutexLock lock{service_state_mutex_}
 
     // curr_capture_status now holds the new service_state_.capture_status. Send commands
     // to the producer based on its value and also based on the value of prev_capture_status,
@@ -381,7 +381,7 @@ void ProducerSideServiceImpl::ReceiveEventsThread(
     if (!stream->Read(request)) break;
 
     {
-      absl::MutexLock lock{&service_state_mutex_};
+      absl::MutexLock lock{service_state_mutex_};
       if (service_state_.exit_requested) {
         break;
       }
@@ -392,7 +392,7 @@ void ProducerSideServiceImpl::ReceiveEventsThread(
         // We use ReaderMutexLock because the mutex guards the value of producer_event_processor_,
         // it does not guard calls to ProcessEvent nor the internal state of the object implementing
         // the interface. The interface implementation is by itself thread-safe.
-        absl::ReaderMutexLock lock{&producer_event_processor_mutex_};
+        absl::ReaderMutexLock lock{producer_event_processor_mutex_};
         // producer_event_processor_ can be nullptr if a producer sends events while not capturing.
         // Don't log an error in such a case as it could easily spam the logs.
         if (producer_event_processor_ != nullptr) {
@@ -405,7 +405,7 @@ void ProducerSideServiceImpl::ReceiveEventsThread(
 
       case orbit_grpc_protos::ReceiveCommandsAndSendEventsRequest::kAllEventsSent: {
         ORBIT_LOG("Received AllEventsSent from CaptureEventProducer");
-        absl::MutexLock lock{&service_state_mutex_};
+        absl::MutexLock lock{service_state_mutex_};
         switch (service_state_.capture_status) {
           case CaptureStatus::kCaptureStarted: {
             ORBIT_ERROR("CaptureEventProducer sent AllEventsSent while still capturing");
@@ -439,7 +439,7 @@ void ProducerSideServiceImpl::ReceiveEventsThread(
 
   ORBIT_ERROR("Receiving ReceiveCommandsAndSendEventsRequest from CaptureEventProducer");
   {
-    absl::MutexLock lock{&service_state_mutex_};
+    absl::MutexLock lock{service_state_mutex_};
     // Producer has disconnected: treat this as if it had sent all its CaptureEvents.
     if (!*all_events_sent_received &&
         (service_state_.capture_status == CaptureStatus::kCaptureStarted ||

--- a/src/ProducerSideService/ProducerSideServiceImplTest.cpp
+++ b/src/ProducerSideService/ProducerSideServiceImplTest.cpp
@@ -38,7 +38,7 @@ class FakeProducer {
     ASSERT_NE(stub, nullptr);
 
     {
-      absl::WriterMutexLock lock{&context_and_stream_mutex_};
+      absl::WriterMutexLock lock{context_and_stream_mutex_};
       EXPECT_EQ(context_, nullptr);
       EXPECT_EQ(stream_, nullptr);
       context_ = std::make_unique<grpc::ClientContext>();
@@ -50,7 +50,7 @@ class FakeProducer {
       while (true) {
         orbit_grpc_protos::ReceiveCommandsAndSendEventsResponse response;
         {
-          absl::ReaderMutexLock lock{&context_and_stream_mutex_};
+          absl::ReaderMutexLock lock{context_and_stream_mutex_};
           ASSERT_NE(stream_, nullptr);
           if (!stream_->Read(&response)) {
             break;
@@ -76,7 +76,7 @@ class FakeProducer {
   }
 
   void SendBufferedCaptureEvents(int32_t num_to_send) {
-    absl::ReaderMutexLock lock{&context_and_stream_mutex_};
+    absl::ReaderMutexLock lock{context_and_stream_mutex_};
     ASSERT_NE(stream_, nullptr);
     orbit_grpc_protos::ReceiveCommandsAndSendEventsRequest request;
     request.mutable_buffered_capture_events();
@@ -85,20 +85,20 @@ class FakeProducer {
     }
 
     {
-      absl::MutexLock write_lock{&exclusive_writes_mutex_};
+      absl::MutexLock write_lock{exclusive_writes_mutex_};
       bool written = stream_->Write(request);
       EXPECT_TRUE(written);
     }
   }
 
   void SendAllEventsSent() {
-    absl::ReaderMutexLock lock{&context_and_stream_mutex_};
+    absl::ReaderMutexLock lock{context_and_stream_mutex_};
     ASSERT_NE(stream_, nullptr);
     orbit_grpc_protos::ReceiveCommandsAndSendEventsRequest request;
     request.mutable_all_events_sent();
 
     {
-      absl::MutexLock write_lock{&exclusive_writes_mutex_};
+      absl::MutexLock write_lock{exclusive_writes_mutex_};
       bool written = stream_->Write(request);
       EXPECT_TRUE(written);
     }
@@ -106,7 +106,7 @@ class FakeProducer {
 
   void FinishRpc() {
     {
-      absl::ReaderMutexLock lock{&context_and_stream_mutex_};
+      absl::ReaderMutexLock lock{context_and_stream_mutex_};
       if (context_ != nullptr) {
         context_->TryCancel();
         EXPECT_NE(stream_, nullptr);
@@ -117,7 +117,7 @@ class FakeProducer {
       }
     }
     {
-      absl::WriterMutexLock lock{&context_and_stream_mutex_};
+      absl::WriterMutexLock lock{context_and_stream_mutex_};
       stream_ = nullptr;
       context_ = nullptr;
     }

--- a/src/SessionSetup/ConnectToLocalWidget.cpp
+++ b/src/SessionSetup/ConnectToLocalWidget.cpp
@@ -126,7 +126,7 @@ void ConnectToLocalWidget::SetupProcessListUpdater() {
           std::vector<orbit_grpc_protos::ProcessInfo> process_list) {
         if (self == nullptr) return;
         emit self->ProcessListUpdated(
-            QVector<orbit_grpc_protos::ProcessInfo>::fromStdVector(process_list));
+            QVector<orbit_grpc_protos::ProcessInfo>(process_list.begin(), process_list.end()));
       });
 }
 

--- a/src/StringManager/StringManager.cpp
+++ b/src/StringManager/StringManager.cpp
@@ -15,7 +15,7 @@ namespace orbit_string_manager {
 
 // TODO(b/181207737): Make this assert that it is not present and rename to "Add".
 bool StringManager::AddIfNotPresent(uint64_t key, std::string_view str) {
-  absl::MutexLock lock{&mutex_};
+  absl::MutexLock lock{mutex_};
   bool inserted = key_to_string_.emplace(key, str).second;
   if (!inserted) {
     ORBIT_ERROR("String collision for key: %u and string: %s", key, str);
@@ -24,13 +24,13 @@ bool StringManager::AddIfNotPresent(uint64_t key, std::string_view str) {
 }
 
 bool StringManager::AddOrReplace(uint64_t key, std::string_view str) {
-  absl::MutexLock lock{&mutex_};
+  absl::MutexLock lock{mutex_};
   bool inserted = key_to_string_.insert_or_assign(key, str).second;
   return inserted;
 }
 
 std::optional<std::string> StringManager::Get(uint64_t key) const {
-  absl::MutexLock lock{&mutex_};
+  absl::MutexLock lock{mutex_};
   auto it = key_to_string_.find(key);
   if (it != key_to_string_.end()) {
     return it->second;
@@ -39,12 +39,12 @@ std::optional<std::string> StringManager::Get(uint64_t key) const {
 }
 
 bool StringManager::Contains(uint64_t key) const {
-  absl::MutexLock lock{&mutex_};
+  absl::MutexLock lock{mutex_};
   return key_to_string_.contains(key);
 }
 
 void StringManager::Clear() {
-  absl::MutexLock lock{&mutex_};
+  absl::MutexLock lock{mutex_};
   key_to_string_.clear();
 }
 

--- a/src/TestUtils/TemporaryDirectory.cpp
+++ b/src/TestUtils/TemporaryDirectory.cpp
@@ -23,7 +23,7 @@ namespace orbit_test_utils {
 [[nodiscard]] static uint32_t Get4BytesOfRandomness() {
   // Since we keep the mersenne twister engine in static storage, we have to ensure thread safety.
   static absl::Mutex mutex{};
-  absl::MutexLock lock{&mutex};
+  absl::MutexLock lock{mutex};
 
   static std::random_device random_device{};
   static std::mt19937 gen{random_device()};

--- a/src/UserSpaceInstrumentation/InstrumentProcessTest.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcessTest.cpp
@@ -285,8 +285,14 @@ TEST(InstrumentProcessTest, GetErrorMessage) {
 extern "C" long double creall(_Complex long double z);
 extern "C" long double cimagl(_Complex long double z);
 
-// Sets st(0) and st(1). Use optnone instead of noinline to prevent constant folding.
-extern "C" __attribute__((optnone)) _Complex long double ReturnComplexLongDouble() {
+// Sets st(0) and st(1). Disabling optimizations for this function -- clang spells that "optnone",
+// gcc spells it optimize("O0") -- prevents constant folding, which noinline alone would not.
+#if defined(__clang__)
+#define ORBIT_NO_OPTIMIZE __attribute__((optnone))
+#else
+#define ORBIT_NO_OPTIMIZE __attribute__((optimize("O0")))
+#endif
+extern "C" ORBIT_NO_OPTIMIZE _Complex long double ReturnComplexLongDouble() {
   return {42.0L, 43.0L};
 }
 

--- a/src/UserSpaceInstrumentation/TestProcess.cpp
+++ b/src/UserSpaceInstrumentation/TestProcess.cpp
@@ -77,7 +77,7 @@ void TestProcess::Worker() {
       break;
     }
   }
-  absl::MutexLock lock{&joinable_threads_mutex_};
+  absl::MutexLock lock{joinable_threads_mutex_};
   joinable_threads_.emplace(std::this_thread::get_id());
 }
 
@@ -96,7 +96,7 @@ void TestProcess::Workload() {
     // Join the finished threads.
     for (auto& t : threads) {
       const auto id = t.get_id();
-      absl::MutexLock lock{&joinable_threads_mutex_};
+      absl::MutexLock lock{joinable_threads_mutex_};
       if (joinable_threads_.count(id) != 0) {
         joinable_threads_.erase(id);
         t.join();

--- a/src/WindowsProcessService/ProcessServiceImpl.cpp
+++ b/src/WindowsProcessService/ProcessServiceImpl.cpp
@@ -50,7 +50,7 @@ Status ProcessServiceImpl::GetProcessList(ServerContext*, const GetProcessListRe
   std::vector<const Process*> processes;
 
   {
-    absl::MutexLock lock(&mutex_);
+    absl::MutexLock lock(mutex_);
     if (process_list_ == nullptr) {
       process_list_ = orbit_windows_utils::ProcessList::Create();
     }

--- a/src/WindowsTracing/KrabsTracer.cpp
+++ b/src/WindowsTracing/KrabsTracer.cpp
@@ -269,14 +269,14 @@ void KrabsTracer::OnImageLoadEvent(const EVENT_RECORD& record,
                   module.full_path);
     }
 
-    absl::MutexLock lock{&modules_mutex_};
+    absl::MutexLock lock{modules_mutex_};
     modules_.emplace_back(std::move(module));
   }
 }
 
 std::vector<orbit_windows_utils::Module> KrabsTracer::GetLoadedModules() const {
   std::vector<orbit_windows_utils::Module> modules;
-  absl::MutexLock lock{&modules_mutex_};
+  absl::MutexLock lock{modules_mutex_};
   modules = modules_;
   return modules;
 }

--- a/src/WindowsUtils/ProcessLauncher.cpp
+++ b/src/WindowsUtils/ProcessLauncher.cpp
@@ -37,14 +37,14 @@ ErrorMessageOr<uint32_t> ProcessLauncher::LaunchProcessPausedAtEntryPoint(
   OUTCOME_TRY(BusyLoopInfo busy_loop_info,
               launcher->StartWithBusyLoopAtEntryPoint(executable, working_directory, arguments));
   uint32_t pid = busy_loop_info.process_id;
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   ORBIT_CHECK(busy_loop_launchers_by_pid_.count(pid) == 0);
   busy_loop_launchers_by_pid_.emplace(pid, std::move(launcher));
   return pid;
 }
 
 ErrorMessageOr<void> ProcessLauncher::SuspendProcessSpinningAtEntryPoint(uint32_t process_id) {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   auto it = busy_loop_launchers_by_pid_.find(process_id);
   if (it == busy_loop_launchers_by_pid_.end()) {
     return ErrorMessage("Trying to suspend unknown process");
@@ -55,7 +55,7 @@ ErrorMessageOr<void> ProcessLauncher::SuspendProcessSpinningAtEntryPoint(uint32_
 }
 
 ErrorMessageOr<void> ProcessLauncher::ResumeProcessSuspendedAtEntryPoint(uint32_t process_id) {
-  absl::MutexLock lock(&mutex_);
+  absl::MutexLock lock(mutex_);
   auto it = busy_loop_launchers_by_pid_.find(process_id);
   if (it == busy_loop_launchers_by_pid_.end()) {
     return ErrorMessage("Trying to resume unknown process");

--- a/third_party/py-spy-ffi/src/lib.rs
+++ b/third_party/py-spy-ffi/src/lib.rs
@@ -3,7 +3,7 @@
 //! This crate provides a C-compatible interface to py-spy's Python profiling
 //! capabilities, allowing C++ code to sample Python stack traces.
 
-use std::ffi::{CStr, CString};
+use std::ffi::CString;
 use std::os::raw::{c_char, c_int};
 use std::ptr;
 
@@ -290,6 +290,7 @@ pub extern "C" fn pyspy_error_string(error_code: c_int) -> *const c_char {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::ffi::CStr;
 
     #[test]
     fn test_error_string() {


### PR DESCRIPTION
## What

`bazel build //...` printed thousands of warnings from Orbit's own code — the build only *looked* clean because the warnings Orbit cares most about are already `-Werror`. After this change a full build emits **zero** warnings from first-party code. (Dependency warnings are untouched: they come in via `-isystem` and are not held to this standard.)

## Warnings fixed

| Warning | Count | Fix |
| --- | --- | --- |
| `-Wdeprecated-declarations` (Abseil) | ~2950 | Reference-taking `absl::MutexLock`/`ReaderMutexLock`/`WriterMutexLock` constructors; `lock()`/`unlock()`/`unlock_shared()` instead of `Lock()`/`Unlock()`/`ReaderUnlock()` |
| `-Wdeprecated-declarations` (`orbit_paths::*Unsafe`) | 44 | Callers migrated to the `ErrorMessageOr` variants |
| `-Wdeprecated-declarations` (`testing::Invoke`) | 30 | Wrapper dropped — gmock builds actions from callables directly |
| `-Wdeprecated-declarations` (Qt) | 11 | `angleDelta()`/`position()`, `QVector` iterator-pair ctor, `Qt::NoModifier` |
| `-Wdeprecated-declarations` (no replacement exists) | 8 | Local suppression + comment |
| `-Wunused-result` | 1 | Report the `ParseFromArray` failure |
| `-Wattributes` | 1 | `optnone` is clang-only; gcc gets `optimize("O0")` |
| protoc unused import | 1 | Dropped `code_block.proto` from `services.proto` |
| rustc unused import | 1 | `CStr` moved into the test module |

## Notes on judgement calls

- **`orbit_paths::*Unsafe`** — these were deprecated with `TODO(b/2389…)` and still had live callers. Callers now use the safe variants. Where the surrounding code has no error path (`main`'s log directory, `SymbolLoader`'s cache directory) the previous fatal behaviour is preserved explicitly, so nothing changes at runtime. The preset/user-data/app-data dialogs in `OrbitMainWindow` now surface the error instead of aborting. Inside `Paths.cpp` the `Unsafe` functions build on private `*OrDie` helpers so they no longer warn at each other.
- **Suppressions** are used only where there is genuinely nothing to migrate to, each with a comment: the v0/v1 Orbit API function tables (ABI that instrumented binaries depend on), `FunctionInfo::GetAbsoluteAddress` (blocked on `TODO(b/191248550)`), `std::wstring_convert` (deprecated by C++17 with no standard replacement), and `PathsTest`, which tests the deprecated API on purpose.
- **Unbuilt / Windows-only sources** (`OrbitVulkanLayer`, `WindowsTracing`, `WindowsUtils`, …) got the same mechanical Abseil change so they do not drift, but they are not compiled by the Linux build and so are not verified here.

## Testing

- `bazel build //...` — clean, no first-party warnings.
- `bazel test //...` — 48 pass, 2 skipped, 1 failure: `UserSpaceInstrumentation.InstrumentProcessTest.Instrument`, which is **flaky on `main` too** (4/5 runs fail on `main`, 2/5 on this branch). Not related to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)