### PR TITLE
Give the injected initialization thread its own thread-local storage

### DIFF
--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -12,7 +12,6 @@
 #include <absl/types/span.h>
 #include <capstone/capstone.h>
 #include <dlfcn.h>
-#include <sched.h>
 #include <unistd.h>
 
 #include <algorithm>
@@ -135,48 +134,6 @@ bool IsBlocklisted(std::string_view function_name) {
       "__GI_memcpy",
   };
   return kBlocklist.contains(function_name);
-}
-
-// MachineCodeForCloneCall creates the code to spawn a new thread inside the target process by using
-// the clone syscall. This thread is used to execute the initialization code inside the target.
-// Note that calling the result of the clone call a "thread" is a bit of a misnomer: We
-// do not create a new data structure for thread local storage but use the one of the thread we
-// halted.
-ErrorMessageOr<MachineCode> MachineCodeForCloneCall(pid_t pid, absl::Span<const ModuleInfo> modules,
-                                                    void* library_handle, uint64_t top_of_stack) {
-  constexpr uint64_t kCloneFlags =
-      CLONE_FILES | CLONE_FS | CLONE_IO | CLONE_SIGHAND | CLONE_SYSVSEM | CLONE_THREAD | CLONE_VM;
-  constexpr uint32_t kSyscallNumberClone = 0x38;
-  constexpr uint32_t kSyscallNumberExit = 0x3c;
-  constexpr const char* kInitializeInstrumentationFunctionName = "InitializeInstrumentation";
-  OUTCOME_TRY(void* initialize_instrumentation_function_address,
-              DlsymInTracee(pid, modules, library_handle, kInitializeInstrumentationFunctionName));
-  MachineCode code;
-  code.AppendBytes({0x48, 0xbf})
-      .AppendImmediate64(kCloneFlags)  // mov rdi, kCloneFlags
-      .AppendBytes({0x48, 0xbe})
-      .AppendImmediate64(top_of_stack)  // mov rsi, top_of_stack
-      .AppendBytes({0x48, 0xba})
-      .AppendImmediate64(0x0)  // mov rdx, parent_tid
-      .AppendBytes({0x49, 0xba})
-      .AppendImmediate64(0x0)  // mov r10, child_tid
-      .AppendBytes({0x49, 0xb8})
-      .AppendImmediate64(0x0)           // mov r8, tls
-      .AppendBytes({0x48, 0xc7, 0xc0})  // mov rax, kSyscallNumberClone
-      .AppendImmediate32(kSyscallNumberClone)
-      .AppendBytes({0x0f, 0x05})                          // syscall (clone)
-      .AppendBytes({0x48, 0x85, 0xc0})                    // testq	rax, rax
-      .AppendBytes({0x0f, 0x84, 0x01, 0x00, 0x00, 0x00})  // jz 0x01(rip)
-      .AppendBytes({0xcc})                                // int3
-      .AppendBytes({0x48, 0xb8})
-      .AppendImmediate64(absl::bit_cast<uint64_t>(
-          initialize_instrumentation_function_address))  // mov rax, initialize_instrumentation
-      .AppendBytes({0xff, 0xd0})                         // call rax
-      .AppendBytes({0x48, 0xc7, 0xc7, 0x00, 0x00, 0x00, 0x00})  // mov rdi, 0x0
-      .AppendBytes({0x48, 0xc7, 0xc0})                          // mov rax, kSyscallNumberExit
-      .AppendImmediate32(kSyscallNumberExit)
-      .AppendBytes({0x0f, 0x05});  // syscall (exit)
-  return code;
 }
 
 ErrorMessageOr<void> WaitForThreadToExit(pid_t pid, pid_t tid) {
@@ -482,15 +439,38 @@ ErrorMessageOr<std::unique_ptr<InstrumentedProcess>> InstrumentedProcess::Create
   const absl::flat_hash_set<pid_t> tids_before_injection(tids_as_vector.begin(),
                                                          tids_as_vector.end());
 
-  // Call initialization code in a new thread.
+  // Let the injected library start a thread of its own and run the initialization code on it. The
+  // thread is created by the target's own libc, with pthread_create, so that it has thread-local
+  // storage of its own: a thread fabricated here with a raw clone syscall shares the storage of the
+  // thread we halted, and the initialization -- gRPC allocating dynamic TLS, starting threads --
+  // then works through the bookkeeping of a thread that runs at the same time.
   ORBIT_LOG("Initializing instrumentation library and setting up communication to OrbitService");
-  constexpr uint64_t kStackSize = 8ULL * 1024ULL * 1024ULL;
-  OUTCOME_TRY(auto&& thread_stack_memory, MemoryInTracee::Create(pid, 0, kStackSize));
-  const uint64_t top_of_stack = thread_stack_memory->GetAddress() + kStackSize;
-  OUTCOME_TRY(auto&& code, MachineCodeForCloneCall(pid, modules, library_handle, top_of_stack));
-  const uint64_t code_size = code.GetResultAsVector().size();
-  OUTCOME_TRY(auto&& code_memory, MemoryInTracee::Create(pid, 0, code_size));
-  OUTCOME_TRY(auto&& init_thread_tid, ExecuteMachineCode(*code_memory, code));
+  constexpr const char* kInitializeInstrumentationFunctionName =
+      "InitializeInstrumentationInNewThread";
+  OUTCOME_TRY(void* initialize_instrumentation_function_address,
+              DlsymInTracee(pid, modules, library_handle,
+                            kInitializeInstrumentationFunctionName));
+  // The code below is what ExecuteInProcess would generate, but the memory holding it is ours to
+  // free: ExecuteInProcess frees its scratch memory as soon as the call returns, and the munmap
+  // that takes needs a syscall instruction placed into a page of the target -- which is not safe to
+  // do once the initialization thread this call starts is running. The memory is freed further
+  // down, after we stopped the target again.
+  // movabsq rax, initialize_instrumentation    48 b8 initialize_instrumentation
+  // call rax                                   ff d0
+  // int3                                       cc
+  MachineCode code;
+  code.AppendBytes({0x48, 0xb8})
+      .AppendImmediate64(absl::bit_cast<uint64_t>(initialize_instrumentation_function_address))
+      .AppendBytes({0xff, 0xd0})
+      .AppendBytes({0xcc});
+  OUTCOME_TRY(auto&& code_memory, MemoryInTracee::Create(pid, 0, code.GetResultAsVector().size()));
+  OUTCOME_TRY(const uint64_t init_thread_tid_as_uint64, ExecuteMachineCode(*code_memory, code));
+  const auto init_thread_tid = static_cast<pid_t>(init_thread_tid_as_uint64);
+  if (init_thread_tid == -1) {
+    return ErrorMessage(
+        "Unable to start the initialization thread of the user space instrumentation library in "
+        "the target process.");
+  }
 
   // Manually detach such that we can wait for the initilization to finish and detect the newly
   // spawned threads.
@@ -510,7 +490,6 @@ ErrorMessageOr<std::unique_ptr<InstrumentedProcess>> InstrumentedProcess::Create
                                                  }
                                                }};
   OUTCOME_TRY(SetOrbitThreadsInTarget(pid, modules, library_handle, orbit_threads));
-  OUTCOME_TRY(thread_stack_memory->Free());
   OUTCOME_TRY(code_memory->Free());
 
   ORBIT_LOG("Initialization of instrumentation library done");

--- a/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
+++ b/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
@@ -5,9 +5,13 @@
 #include "OrbitUserSpaceInstrumentation.h"
 
 #include <google/protobuf/arena.h>
+#include <pthread.h>
+#include <sched.h>
+#include <sys/types.h>
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cstddef>
 #include <stack>
 #include <utility>
@@ -148,6 +152,19 @@ LockFreeUserSpaceInstrumentationEventProducer& GetCaptureEventProducer() {
   return producer;
 }
 
+// The id of the thread started by InitializeInstrumentationInNewThread, published by the thread
+// itself as soon as it starts running.
+std::atomic<pid_t> initialization_thread_tid{-1};
+
+// Initialize the LockFreeUserSpaceInstrumentationEventProducer and establish the connection to
+// OrbitService. Runs on the thread started by InitializeInstrumentationInNewThread below.
+void* InitializeInstrumentationThreadMain(void* /*argument*/) {
+  initialization_thread_tid.store(orbit_base::GetCurrentThreadIdNative(),
+                                  std::memory_order_release);
+  GetCaptureEventProducer();
+  return nullptr;
+}
+
 // Provide a thread local bool to keep track of whether the current thread is inside the payload we
 // injected. If that is the case we avoid further instrumentation.
 bool& GetIsInPayload() {
@@ -161,9 +178,26 @@ bool& GetIsInPayload() {
 // need to be visible to the tracee must be marked with `[[gnu::visibility("default")]]`. Check
 // out the CMakeLists.txt file for more information.
 
-// Initialize the LockFreeUserSpaceInstrumentationEventProducer and establish the connection to
-// OrbitService.
-[[gnu::visibility("default")]] void InitializeInstrumentation() { GetCaptureEventProducer(); }
+[[gnu::visibility("default")]] pid_t InitializeInstrumentationInNewThread() {
+  initialization_thread_tid.store(-1, std::memory_order_relaxed);
+
+  pthread_t thread{};
+  if (pthread_create(&thread, nullptr, &InitializeInstrumentationThreadMain, nullptr) != 0) {
+    return -1;
+  }
+  // Nobody joins this thread: OrbitService waits for it to disappear from the target's task list.
+  pthread_detach(thread);
+
+  // Hand the thread id back to OrbitService, which uses it to tell when the initialization is done.
+  // The new thread publishes it before doing any work, so this spins only for as long as it takes
+  // the scheduler to get to it. All the other threads of the target are stopped while we are called
+  // -- the new one is not, because OrbitService never attached to it.
+  pid_t tid = -1;
+  while ((tid = initialization_thread_tid.load(std::memory_order_acquire)) == -1) {
+    sched_yield();
+  }
+  return tid;
+}
 
 // Records up to six more of Orbit's own thread ids. Ids that are -1 are
 // ignored, so the caller can leave the last batch partially filled.

--- a/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.h
+++ b/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.h
@@ -13,12 +13,20 @@
 // timestamp as obtained from orbit_base::CaptureTimestampNs.
 extern "C" void StartNewCapture(uint64_t capture_start_timestamp_ns);
 
-// InitializeInstrumentation needs to be called once after this library is injected into the target
-// process. It sets up the communication to OrbitService.
-extern "C" void InitializeInstrumentation();
+// InitializeInstrumentationInNewThread needs to be called once after this library is injected into
+// the target process. It starts a thread that sets up the communication to OrbitService and returns
+// the id of that thread, or -1 if the thread could not be started.
+//
+// The initialization runs on a thread of the target's own making, created with pthread_create, so
+// that it gets thread-local storage of its own. It used to run on a thread that Orbit fabricated
+// with a raw clone syscall, which shares the thread-local storage of the thread it was cloned from.
+// Everything the initialization does with thread-local storage -- gRPC allocates dynamic TLS and
+// starts threads of its own -- then goes through the bookkeeping of a thread that is running at the
+// same time, which is not something glibc supports.
+extern "C" pid_t InitializeInstrumentationInNewThread();
 
 // Injecting this library spawns threads, immediately after the call to
-// InitializeInstrumentation above: two of Orbit's own plus however many the gRPC version in use
+// InitializeInstrumentationInNewThread above: two of Orbit's own plus however many the gRPC version in use
 // starts to communicate with OrbitService. OrbitService detects them and calls AddOrbitThreads to
 // register their ids, so that events from these threads can be ignored in EntryPayload.
 //


### PR DESCRIPTION
## The hazard

`InstrumentedProcess::Create` starts the injected library's initialization on a thread it builds by hand, with a `clone` syscall that has no `CLONE_SETTLS`. The comment above that code says what it costs:

> Note that calling the result of the clone call a "thread" is a bit of a misnomer: We do not create a new data structure for thread local storage but use the one of the thread we halted.

What runs on that thread is gRPC's startup. It allocates dynamic thread-local storage and it creates threads of its own — both of which walk the thread-local bookkeeping of whichever thread we halted, and that thread is running again by then, because OrbitService detaches immediately after the clone so it can wait for the initialization from outside.

When the target dies during injection, the backtraces come from exactly there:

```
libc.so.6(abort+0x27)
libc.so.6(+0xb403f)
ld-linux-x86-64.so.2(_dl_allocate_tls+0x37)
libc.so.6(pthread_create+0xc32)
liborbituserspaceinstrumentation.so(grpc_core::Thread::Thread(...))
liborbituserspaceinstrumentation.so(WorkStealingThreadPoolImpl::StartThread())
```

```
ld-linux-x86-64.so.2(__tls_get_addr+0x3c)
liborbituserspaceinstrumentation.so(WorkStealingThreadPool::ThreadState::ThreadBody())
```

## The change

The library gets a new entry point, `InitializeInstrumentationInNewThread`, which starts the initialization with `pthread_create` — a thread of the target's own libc, with thread-local storage of its own — and returns its thread id. OrbitService calls that instead of assembling a clone, and waits for the returned id the way it did before. The clone machine code and the 8 MB stack it needed are gone.

The scratch memory for the call is allocated here rather than through `ExecuteInProcess`, because `ExecuteInProcess` frees its scratch memory as soon as the call returns, and freeing it means placing a `syscall` instruction into a page of the target — which is no longer safe once the initialization thread is running. It is freed further down, after the target has been stopped again.

## What this does not do

It does not make `InstrumentProcessTest.Instrument` pass reliably. That test is broken by a separate problem — the second copy of libc that `dlmopen` brings into the target grows the same `brk` heap as the target's own allocator — which is diagnosed in #18. With 20 runs of the test on either side, this branch passes 9 and `main` passes 7: the same, within noise.

So this is a latent-hazard fix without a test that turns green, and worth reviewing as such. It is independent of #18 and of #17; if #18 lands first, the skipped test bodies here are the ones that would exercise this path once the allocator problem is solved.

## Checks

- `bazel test //src/UserSpaceInstrumentation:all` — everything outside `InstrumentProcessTest` passes (20/20).
- `bazel test //src/LinuxTracingIntegrationTests:all` — passes (the tests that instrument need root and skip here).
- On the runs where `InstrumentProcessTest.Instrument` does complete, the full instrument/uninstrument cycle works through the new entry point, five iterations included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)