### PR TITLE
Stop dynamic instrumentation from corrupting the target's heap

### DIFF
--- a/src/LinuxTracingIntegrationTests/BUILD.bazel
+++ b/src/LinuxTracingIntegrationTests/BUILD.bazel
@@ -3,9 +3,20 @@
 # found in the LICENSE file.
 
 load("//bazel:copts.bzl", "ORBIT_COPTS")
+load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 
 package(default_visibility = ["//visibility:public"])
+
+# OrbitService looks for the instrumentation library next to itself, so the test that runs
+# OrbitService needs a copy of it in its own output directory -- the same thing //src/Service does
+# for the service binary.
+copy_file(
+    name = "copy_liborbituserspaceinstrumentation_so",
+    src = "//src/UserSpaceInstrumentation:liborbituserspaceinstrumentation.so",
+    out = "liborbituserspaceinstrumentation.so",
+    is_executable = True,
+)
 
 cc_binary(
     name = "libIntegrationTestPuppetSharedObject.so",
@@ -85,7 +96,10 @@ cc_test(
         "OrbitServiceIntegrationTest.cpp",
     ],
     copts = ORBIT_COPTS,
-    data = [":libIntegrationTestPuppetSharedObject.so"],
+    data = [
+        ":libIntegrationTestPuppetSharedObject.so",
+        ":liborbituserspaceinstrumentation.so",
+    ],
     linkstatic = True,
     tags = [
         "exclusive",

--- a/src/UserSpaceInstrumentation/BUILD.bazel
+++ b/src/UserSpaceInstrumentation/BUILD.bazel
@@ -89,6 +89,17 @@ cc_binary(
     ],
     copts = ORBIT_COPTS + [
         "-Isrc/UserSpaceInstrumentation",
+        # Everything this library brings along -- gRPC, protobuf, abseil, the
+        # C++ runtime -- stays inside it. Only the payloads below are visible
+        # to the outside, which is what lets the library be loaded into a
+        # target that has copies of the same code of its own.
+        "-fvisibility=hidden",
+        "-fvisibility-inlines-hidden",
+    ],
+    linkopts = [
+        # The visibility flags above only cover this target's own translation
+        # units; the static archives linked into it are hidden here.
+        "-Wl,--exclude-libs,ALL",
     ],
     linkshared = True,
     linkstatic = True,

--- a/src/UserSpaceInstrumentation/BUILD.bazel
+++ b/src/UserSpaceInstrumentation/BUILD.bazel
@@ -152,11 +152,8 @@ cc_test(
         ":liborbituserspaceinstrumentation.so",
     ],
     includes = ["."],
-    # InstrumentProcessTest.Instrument has a race between the injected
-    # thread exiting and gRPC's event-engine thread pool being created.
-    # Diagnosed, not yet fixed; CI runs this suite non-gating.
-    tags = ["known_flaky"],
     deps = [
+        "//src/ObjectUtils",
         "//src/Test:gtest_main",
         "//src/TestUtils",
         "//src/UserSpaceInstrumentation",

--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -436,8 +436,24 @@ ErrorMessageOr<std::unique_ptr<InstrumentedProcess>> InstrumentedProcess::Create
   // in the previous run.
   OUTCOME_TRY(const bool already_injected, AlreadyInjected(modules));
 
+  // Load the library into the linker namespace the target already has, not into one of its own.
+  //
+  // A namespace of its own comes with a second copy of libc, and the two copies grow the same brk
+  // heap from their own main arena, each assuming the memory above its top chunk is its own. They
+  // hand out overlapping memory and the target dies -- glibc reports "malloc(): unsorted double
+  // linked list corrupted" or asserts in sysmalloc that nothing else moved the program break --
+  // while the injected library is starting up, which is heavy on allocation.
+  //
+  // A namespace of its own was introduced (#4327) when Orbit could be built against gRPC and
+  // protobuf as *system* libraries, i.e. dynamically linked: the target and this library would then
+  // share one libprotobuf, and registering the same generated descriptors twice in one protobuf
+  // aborts. That is what the namespace kept apart. This build links gRPC, protobuf and abseil
+  // statically into liborbituserspaceinstrumentation.so and hides every one of their symbols
+  // (see the BUILD file), so this library carries its own copies with no way for them to meet the
+  // target's -- which is the same reason liborbit.so, the Orbit API library, is loaded into the
+  // initial namespace as well.
   auto library_handle_or_error =
-      DlmopenInTracee(pid, modules, library_path, RTLD_NOW, LinkerNamespace::kCreateNewNamespace);
+      DlmopenInTracee(pid, modules, library_path, RTLD_NOW, LinkerNamespace::kUseInitialNamespace);
   if (library_handle_or_error.has_error()) {
     return ErrorMessage(absl::StrFormat("Unable to open library in tracee: %s",
                                         library_handle_or_error.error().message()));

--- a/src/UserSpaceInstrumentation/InstrumentProcess.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcess.cpp
@@ -12,7 +12,6 @@
 #include <absl/types/span.h>
 #include <capstone/capstone.h>
 #include <dlfcn.h>
-#include <sched.h>
 #include <unistd.h>
 
 #include <algorithm>
@@ -135,48 +134,6 @@ bool IsBlocklisted(std::string_view function_name) {
       "__GI_memcpy",
   };
   return kBlocklist.contains(function_name);
-}
-
-// MachineCodeForCloneCall creates the code to spawn a new thread inside the target process by using
-// the clone syscall. This thread is used to execute the initialization code inside the target.
-// Note that calling the result of the clone call a "thread" is a bit of a misnomer: We
-// do not create a new data structure for thread local storage but use the one of the thread we
-// halted.
-ErrorMessageOr<MachineCode> MachineCodeForCloneCall(pid_t pid, absl::Span<const ModuleInfo> modules,
-                                                    void* library_handle, uint64_t top_of_stack) {
-  constexpr uint64_t kCloneFlags =
-      CLONE_FILES | CLONE_FS | CLONE_IO | CLONE_SIGHAND | CLONE_SYSVSEM | CLONE_THREAD | CLONE_VM;
-  constexpr uint32_t kSyscallNumberClone = 0x38;
-  constexpr uint32_t kSyscallNumberExit = 0x3c;
-  constexpr const char* kInitializeInstrumentationFunctionName = "InitializeInstrumentation";
-  OUTCOME_TRY(void* initialize_instrumentation_function_address,
-              DlsymInTracee(pid, modules, library_handle, kInitializeInstrumentationFunctionName));
-  MachineCode code;
-  code.AppendBytes({0x48, 0xbf})
-      .AppendImmediate64(kCloneFlags)  // mov rdi, kCloneFlags
-      .AppendBytes({0x48, 0xbe})
-      .AppendImmediate64(top_of_stack)  // mov rsi, top_of_stack
-      .AppendBytes({0x48, 0xba})
-      .AppendImmediate64(0x0)  // mov rdx, parent_tid
-      .AppendBytes({0x49, 0xba})
-      .AppendImmediate64(0x0)  // mov r10, child_tid
-      .AppendBytes({0x49, 0xb8})
-      .AppendImmediate64(0x0)           // mov r8, tls
-      .AppendBytes({0x48, 0xc7, 0xc0})  // mov rax, kSyscallNumberClone
-      .AppendImmediate32(kSyscallNumberClone)
-      .AppendBytes({0x0f, 0x05})                          // syscall (clone)
-      .AppendBytes({0x48, 0x85, 0xc0})                    // testq	rax, rax
-      .AppendBytes({0x0f, 0x84, 0x01, 0x00, 0x00, 0x00})  // jz 0x01(rip)
-      .AppendBytes({0xcc})                                // int3
-      .AppendBytes({0x48, 0xb8})
-      .AppendImmediate64(absl::bit_cast<uint64_t>(
-          initialize_instrumentation_function_address))  // mov rax, initialize_instrumentation
-      .AppendBytes({0xff, 0xd0})                         // call rax
-      .AppendBytes({0x48, 0xc7, 0xc7, 0x00, 0x00, 0x00, 0x00})  // mov rdi, 0x0
-      .AppendBytes({0x48, 0xc7, 0xc0})                          // mov rax, kSyscallNumberExit
-      .AppendImmediate32(kSyscallNumberExit)
-      .AppendBytes({0x0f, 0x05});  // syscall (exit)
-  return code;
 }
 
 ErrorMessageOr<void> WaitForThreadToExit(pid_t pid, pid_t tid) {
@@ -498,15 +455,38 @@ ErrorMessageOr<std::unique_ptr<InstrumentedProcess>> InstrumentedProcess::Create
   const absl::flat_hash_set<pid_t> tids_before_injection(tids_as_vector.begin(),
                                                          tids_as_vector.end());
 
-  // Call initialization code in a new thread.
+  // Let the injected library start a thread of its own and run the initialization code on it. The
+  // thread has to be created by the target's own libc, with pthread_create: a thread fabricated
+  // here with a raw clone syscall would share the thread-local storage of the thread we halted, and
+  // the dynamic TLS and heap bookkeeping done while gRPC starts up would then corrupt the target's
+  // heap.
   ORBIT_LOG("Initializing instrumentation library and setting up communication to OrbitService");
-  constexpr uint64_t kStackSize = 8ULL * 1024ULL * 1024ULL;
-  OUTCOME_TRY(auto&& thread_stack_memory, MemoryInTracee::Create(pid, 0, kStackSize));
-  const uint64_t top_of_stack = thread_stack_memory->GetAddress() + kStackSize;
-  OUTCOME_TRY(auto&& code, MachineCodeForCloneCall(pid, modules, library_handle, top_of_stack));
-  const uint64_t code_size = code.GetResultAsVector().size();
-  OUTCOME_TRY(auto&& code_memory, MemoryInTracee::Create(pid, 0, code_size));
-  OUTCOME_TRY(auto&& init_thread_tid, ExecuteMachineCode(*code_memory, code));
+  constexpr const char* kInitializeInstrumentationFunctionName =
+      "InitializeInstrumentationInNewThread";
+  OUTCOME_TRY(void* initialize_instrumentation_function_address,
+              DlsymInTracee(pid, modules, library_handle,
+                            kInitializeInstrumentationFunctionName));
+  // The code below is what ExecuteInProcess would generate, but the memory holding it is ours to
+  // free: ExecuteInProcess frees its scratch memory as soon as the call returns, and the munmap
+  // that takes needs a syscall instruction placed into a page of the target -- which is not safe to
+  // do once the initialization thread this call starts is running. The memory is freed further
+  // down, after we stopped the target again.
+  // movabsq rax, initialize_instrumentation    48 b8 initialize_instrumentation
+  // call rax                                   ff d0
+  // int3                                       cc
+  MachineCode code;
+  code.AppendBytes({0x48, 0xb8})
+      .AppendImmediate64(absl::bit_cast<uint64_t>(initialize_instrumentation_function_address))
+      .AppendBytes({0xff, 0xd0})
+      .AppendBytes({0xcc});
+  OUTCOME_TRY(auto&& code_memory, MemoryInTracee::Create(pid, 0, code.GetResultAsVector().size()));
+  OUTCOME_TRY(const uint64_t init_thread_tid_as_uint64, ExecuteMachineCode(*code_memory, code));
+  const auto init_thread_tid = static_cast<pid_t>(init_thread_tid_as_uint64);
+  if (init_thread_tid == -1) {
+    return ErrorMessage(
+        "Unable to start the initialization thread of the user space instrumentation library in "
+        "the target process.");
+  }
 
   // Manually detach such that we can wait for the initilization to finish and detect the newly
   // spawned threads.
@@ -526,7 +506,6 @@ ErrorMessageOr<std::unique_ptr<InstrumentedProcess>> InstrumentedProcess::Create
                                                  }
                                                }};
   OUTCOME_TRY(SetOrbitThreadsInTarget(pid, modules, library_handle, orbit_threads));
-  OUTCOME_TRY(thread_stack_memory->Free());
   OUTCOME_TRY(code_memory->Free());
 
   ORBIT_LOG("Initialization of instrumentation library done");

--- a/src/UserSpaceInstrumentation/InstrumentProcessTest.cpp
+++ b/src/UserSpaceInstrumentation/InstrumentProcessTest.cpp
@@ -17,6 +17,8 @@
 #include <array>
 #include <chrono>
 #include <cstdint>
+#include <cstdlib>
+#include <cstring>
 #include <filesystem>
 #include <memory>
 #include <random>
@@ -26,6 +28,8 @@
 #include <vector>
 
 #include "GrpcProtos/capture.pb.h"
+#include "ObjectUtils/ElfFile.h"
+#include "OrbitBase/ExecutablePath.h"
 #include "OrbitBase/GetProcessIds.h"
 #include "OrbitBase/Logging.h"
 #include "OrbitBase/Result.h"
@@ -41,7 +45,10 @@ namespace {
 
 using orbit_test_utils::HasErrorWithMessage;
 using orbit_test_utils::HasNoError;
+using ::testing::AnyOf;
 using ::testing::HasSubstr;
+using ::testing::IsSupersetOf;
+using ::testing::Not;
 
 constexpr int kFunctionId1 = 42;
 constexpr int kFunctionId2 = 43;
@@ -65,6 +72,21 @@ orbit_grpc_protos::CaptureOptions BuildCaptureOptions() {
   AddFunctionToCaptureOptions(&capture_options, "ReturnImmediately", kFunctionId2);
 
   return capture_options;
+}
+
+// Fails if the target is not running anymore, naming the signal that took it down: the heap errors
+// glibc reports end in abort(), and the message it prints goes to the target's stderr.
+void ExpectTargetIsRunning(pid_t pid, std::string_view when) {
+  int status = 0;
+  const pid_t waited = waitpid(pid, &status, WNOHANG);
+  if (waited == 0) return;
+  if (waited == pid && WIFSIGNALED(status)) {
+    ADD_FAILURE() << "The target died from signal " << WTERMSIG(status) << " " << when
+                  << "; if that is SIGABRT, look for the message glibc printed on stderr.";
+    return;
+  }
+  ADD_FAILURE() << "The target is gone " << when << " (waitpid returned " << waited << ", status 0x"
+                << std::hex << status << ").";
 }
 
 [[nodiscard]] InstrumentationManager* GetInstrumentationManager() {
@@ -237,6 +259,95 @@ TEST(InstrumentProcessTest, Instrument) {
   // End child pid_process_2.
   kill(pid_process_2, SIGKILL);
   waitpid(pid_process_2, nullptr, 0);
+}
+
+// The instrumentation library is loaded into the target with dlopen, and everything it brings with
+// it -- gRPC, protobuf, abseil -- has to stay inside it. In particular it must not bring an
+// allocator of its own: loading it into a linker namespace of its own used to do exactly that,
+// because such a namespace comes with a second copy of libc, and the two main arenas then grew the
+// same brk heap and handed out overlapping memory. The target died of that, with
+// "malloc(): unsorted double linked list corrupted" or the sysmalloc assertion about the program
+// break, right while the injected library was starting up.
+//
+// So: a target that uses its heap the way any real one does has to come out of being instrumented
+// alive.
+TEST(InstrumentProcessTest, TargetHeapSurvivesInstrumentation) {
+  InstrumentationManager* instrumentation_manager = GetInstrumentationManager();
+
+  const pid_t pid = fork();
+  ORBIT_CHECK(pid != -1);
+  if (pid == 0) {
+    prctl(PR_SET_PDEATHSIG, SIGTERM);
+
+    // Hold on to a couple of thousand blocks and keep replacing them, which makes the allocator
+    // grow and shrink the heap the whole time we are being instrumented.
+    constexpr size_t kLiveBlockCount = 2048;
+    static std::array<void*, kLiveBlockCount> live_blocks{};
+    uint32_t random_state = 12345;
+    [[maybe_unused]] volatile int sum = 0;
+    while (true) {
+      for (void*& block : live_blocks) {
+        random_state = random_state * 1103515245 + 12345;
+        free(block);
+        block = malloc(64 + (random_state >> 16) % 32768);
+        memset(block, 0x5a, 32);
+        sum += SomethingToInstrument();
+      }
+    }
+  }
+
+  orbit_grpc_protos::CaptureOptions capture_options = BuildCaptureOptions();
+  capture_options.set_pid(pid);
+  auto result_or_error = instrumentation_manager->InstrumentProcess(capture_options);
+  ASSERT_THAT(result_or_error, HasNoError());
+  EXPECT_TRUE(result_or_error.value().instrumented_function_ids.contains(kFunctionId1));
+
+  // Let the target run instrumented for a while: a corrupted heap is only noticed the next time the
+  // target allocates.
+  std::this_thread::sleep_for(std::chrono::milliseconds{500});
+  ExpectTargetIsRunning(pid, "while instrumented");
+
+  auto result = instrumentation_manager->UninstrumentProcess(pid);
+  ASSERT_THAT(result, HasNoError());
+
+  std::this_thread::sleep_for(std::chrono::milliseconds{500});
+  ExpectTargetIsRunning(pid, "after uninstrumenting");
+
+  kill(pid, SIGKILL);
+  waitpid(pid, nullptr, 0);
+}
+
+// The library injected into the target statically links gRPC, protobuf and abseil, and is loaded
+// into the linker namespace the target already has. That is only safe as long as none of it is
+// visible there: a symbol this library exports can be bound to by its own code in place of the
+// target's copy, or the other way around, and two copies of protobuf that find each other abort
+// over the same descriptors being registered twice. The CMake build hid these symbols; the port to
+// Bazel dropped that, which is what this test is here to catch.
+TEST(InstrumentProcessTest, InstrumentationLibraryExportsNothingButItsPayloads) {
+  const std::filesystem::path library_path =
+      orbit_base::GetExecutableDir() / "liborbituserspaceinstrumentation.so";
+  ASSERT_TRUE(std::filesystem::exists(library_path)) << library_path.string();
+
+  auto elf_file_or_error = orbit_object_utils::CreateElfFile(library_path);
+  ASSERT_THAT(elf_file_or_error, HasNoError());
+  auto symbols_or_error = elf_file_or_error.value()->LoadSymbolsFromDynsym();
+  ASSERT_THAT(symbols_or_error, HasNoError());
+
+  std::vector<std::string> exported_names;
+  for (const orbit_grpc_protos::SymbolInfo& symbol : symbols_or_error.value().symbol_infos()) {
+    exported_names.emplace_back(symbol.demangled_name());
+  }
+
+  // Everything OrbitService calls into the library is here; nothing else has to be.
+  EXPECT_THAT(exported_names,
+              IsSupersetOf({"InitializeInstrumentationInNewThread", "StartNewCapture",
+                            "AddOrbitThreads", "EntryPayload", "ExitPayload"}));
+
+  for (const std::string& name : exported_names) {
+    EXPECT_THAT(name, Not(AnyOf(HasSubstr("grpc"), HasSubstr("protobuf"), HasSubstr("absl"),
+                                HasSubstr("upb"), HasSubstr("google"))))
+        << "The library exports the code it brings along, which must stay private to it.";
+  }
 }
 
 TEST(InstrumentProcessTest, GetErrorMessage) {

--- a/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
+++ b/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
@@ -5,9 +5,13 @@
 #include "OrbitUserSpaceInstrumentation.h"
 
 #include <google/protobuf/arena.h>
+#include <pthread.h>
+#include <sched.h>
+#include <sys/types.h>
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <cstddef>
 #include <stack>
 #include <utility>
@@ -148,6 +152,19 @@ LockFreeUserSpaceInstrumentationEventProducer& GetCaptureEventProducer() {
   return producer;
 }
 
+// The id of the thread started by InitializeInstrumentationInNewThread, published by the thread
+// itself as soon as it starts running.
+std::atomic<pid_t> initialization_thread_tid{-1};
+
+// Initialize the LockFreeUserSpaceInstrumentationEventProducer and establish the connection to
+// OrbitService. Runs on the thread started by InitializeInstrumentationInNewThread below.
+void* InitializeInstrumentationThreadMain(void* /*argument*/) {
+  initialization_thread_tid.store(orbit_base::GetCurrentThreadIdNative(),
+                                  std::memory_order_release);
+  GetCaptureEventProducer();
+  return nullptr;
+}
+
 // Provide a thread local bool to keep track of whether the current thread is inside the payload we
 // injected. If that is the case we avoid further instrumentation.
 bool& GetIsInPayload() {
@@ -162,9 +179,26 @@ bool& GetIsInPayload() {
 // out the BUILD file for more information: the library is loaded into the target's own linker
 // namespace, and only the handful of symbols marked below may be visible there.
 
-// Initialize the LockFreeUserSpaceInstrumentationEventProducer and establish the connection to
-// OrbitService.
-[[gnu::visibility("default")]] void InitializeInstrumentation() { GetCaptureEventProducer(); }
+[[gnu::visibility("default")]] pid_t InitializeInstrumentationInNewThread() {
+  initialization_thread_tid.store(-1, std::memory_order_relaxed);
+
+  pthread_t thread{};
+  if (pthread_create(&thread, nullptr, &InitializeInstrumentationThreadMain, nullptr) != 0) {
+    return -1;
+  }
+  // Nobody joins this thread: OrbitService waits for it to disappear from the target's task list.
+  pthread_detach(thread);
+
+  // Hand the thread id back to OrbitService, which uses it to tell when the initialization is done.
+  // The new thread publishes it before doing any work, so this spins only for as long as it takes
+  // the scheduler to get to it. All the other threads of the target are stopped while we are called
+  // -- the new one is not, because OrbitService never attached to it.
+  pid_t tid = -1;
+  while ((tid = initialization_thread_tid.load(std::memory_order_acquire)) == -1) {
+    sched_yield();
+  }
+  return tid;
+}
 
 // Records up to six more of Orbit's own thread ids. Ids that are -1 are
 // ignored, so the caller can leave the last batch partially filled.

--- a/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
+++ b/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.cpp
@@ -159,7 +159,8 @@ bool& GetIsInPayload() {
 
 // NOTE: All symbols defined here have private linker visibility by default. Symbols that
 // need to be visible to the tracee must be marked with `[[gnu::visibility("default")]]`. Check
-// out the CMakeLists.txt file for more information.
+// out the BUILD file for more information: the library is loaded into the target's own linker
+// namespace, and only the handful of symbols marked below may be visible there.
 
 // Initialize the LockFreeUserSpaceInstrumentationEventProducer and establish the connection to
 // OrbitService.

--- a/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.h
+++ b/src/UserSpaceInstrumentation/OrbitUserSpaceInstrumentation.h
@@ -13,9 +13,16 @@
 // timestamp as obtained from orbit_base::CaptureTimestampNs.
 extern "C" void StartNewCapture(uint64_t capture_start_timestamp_ns);
 
-// InitializeInstrumentation needs to be called once after this library is injected into the target
-// process. It sets up the communication to OrbitService.
-extern "C" void InitializeInstrumentation();
+// InitializeInstrumentationInNewThread needs to be called once after this library is injected into
+// the target process. It starts a thread that sets up the communication to OrbitService and returns
+// the id of that thread, or -1 if the thread could not be started.
+//
+// The initialization runs on a thread of the target's own making, created with pthread_create, so
+// that it gets its own thread-local storage. It must not run on a thread that Orbit fabricated with
+// a raw clone syscall: such a thread shares the thread-local storage of the thread it was cloned
+// from, and the dynamic TLS and heap bookkeeping that gRPC's initialization performs then races
+// with the thread that storage really belongs to, which corrupts the target's heap.
+extern "C" pid_t InitializeInstrumentationInNewThread();
 
 // Injecting this library spawns threads, immediately after the call to
 // InitializeInstrumentation above: two of Orbit's own plus however many the gRPC version in use


### PR DESCRIPTION
Supersedes #18 (which only skipped the failing tests) and #19 (whose change is commit 3 here, now with a test that proves it is needed).

## The symptom

`InstrumentProcessTest.Instrument` failed about half its runs, reporting

```
Unable to initialize process 850634: Unable to find threads spawned by library
injected for user space instrumentation.
```

That message is the end of the story, not the beginning. Giving the target a stderr of its own shows what actually happens: **the target dies of heap corruption while the injected library starts up.**

```
malloc(): unsorted double linked list corrupted
corrupted size vs. prev_size
Fatal glibc error: malloc.c:2371 (sysmalloc): assertion failed:
  ... ((unsigned long) old_end & (pagesize - 1)) == 0
```

It is not a test artifact. A target that uses its heap the way any real one does — a few thousand live blocks, replaced continuously — dies in **14 of 15** instrumentation attempts.

## What instrumentation does, and the three places it went wrong

Instrumenting a process means: attach and stop it, `mmap` scratch memory into it through an injected `syscall` instruction, make the halted thread call `dlopen` on `liborbituserspaceinstrumentation.so`, start a thread inside the target that runs the library's initialization (a gRPC producer that connects back to OrbitService), then write trampolines over the functions to instrument. The library carries gRPC, protobuf and abseil statically linked — 90 MB of code that has to coexist with whatever the target already is.

**1. The library exported everything it carries.** The CMake build hid it all (`CXX_VISIBILITY_PRESET hidden`, `-Wl,--exclude-libs,ALL`); the port to Bazel dropped those, so the library exported **125,921** symbols — every one of protobuf's, gRPC's and abseil's. Symbols that are exported also take part in resolution, so the library's own code can bind to a copy of protobuf belonging to the target, and vice versa.

**2. It was loaded into a linker namespace of its own.** `dlmopen(LM_ID_NEWLM, ...)` gives the library a private namespace — and a **second copy of libc**, visible as two `libc.so.6` mappings in the target. Both copies grow the same `brk` heap from their own main arena, each assuming the memory above its top chunk is its own, and they hand out overlapping memory. That is what the `sysmalloc` assertion above is: glibc checking that nobody else moved the program break.

The namespace was introduced in #4327, when gRPC and protobuf could be *system* libraries, i.e. dynamically linked: target and library would then share one libprotobuf, and registering the same generated descriptors twice in one protobuf aborts. This build links them statically, and with (1) restored, hides them — so there is nothing left to keep apart. `liborbit.so`, the Orbit API library, has always been loaded into the initial namespace for that reason.

**3. The initialization thread had no thread-local storage of its own.** It was created by a hand-assembled `clone` without `CLONE_SETTLS`, and the comment above it said so: *"calling the result of the clone call a 'thread' is a bit of a misnomer: We do not create a new data structure for thread local storage but use the one of the thread we halted."* gRPC's startup then allocates dynamic TLS, spawns threads, and allocates heavily — all through the halted thread's bookkeeping, including the allocator's per-thread cache, which lives in exactly that structure. And that thread is running again by then, because OrbitService detaches right after the clone. Two tasks, one thread's allocator cache. The aborts land in `_dl_allocate_tls` and `__tls_get_addr` on that path.

## Each fix measured on its own

`TargetHeapSurvivesInstrumentation`, the new test:

| build | runs passed |
| --- | --- |
| `main` | 1 / 15 |
| + own TLS for the init thread (#19 alone) | 2 / 10 |
| + hidden symbols and initial namespace | 4 / 10 |
| **all three (this PR)** | **30 / 30** |

Both fixes are needed; neither is sufficient.

## Proof

- `TargetHeapSurvivesInstrumentation` — **30/30**, and **20/20** with the target spending nearly all its time inside `malloc`. 1/15 before.
- Whole `UserSpaceInstrumentationTests` target — **100/100** consecutive runs, then **60/60** more, all 27 tests each time. (One abort was seen in ~300 runs, in a batch whose stderr had been discarded, and has not recurred in the 190 logged runs since; if it shows up again it will be captured.)
- `InstrumentationLibraryExportsNothingButItsPayloads` — reads the library's dynamic symbol table and requires the five payload functions and nothing from gRPC, protobuf or abseil. Removing the visibility flags makes it fail, which is the point: the port lost this property once already.
- The library went from 125,921 exported symbols and 90 MB to **24** and 57 MB.

## Also here

The `known_flaky` tag on the test target described "a race between the injected thread exiting and gRPC's event-engine thread pool being created" — that is not what was happening, and the suite is not flaky any more, so both are gone.

`OrbitServiceIntegrationTests` runs OrbitService but never got a copy of the instrumentation library next to it, the way `//src/Service` does, so `FunctionCallsWithUserSpaceInstrumentation` — the one end-to-end test of dynamic instrumentation, root-only — could only ever have failed with "liborbituserspaceinstrumentation.so not found on system". It gets that copy now.

## Left for later

- `liborbit.so`, the Orbit API library, exports **127,621** symbols and is loaded into the target's initial namespace, where they can be bound to. The same two build flags would fix it; the API path needs root to test end to end, so it is not in this PR.
- `LockFreeBufferCaptureEventProducerTest.DisconnectAndReconnect` and a `ProducerSideServiceImplTest` case each failed once in a heavily parallel `--runs_per_test=5` sweep, and pass 20/20 in isolation on `main` as well. Timing-sensitive, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)