### PR TITLE
CI: nightly OrbitService matrix on Ubuntu 18.04+ and other distros

### DIFF
--- a/.github/workflows/linux-distro-matrix.yml
+++ b/.github/workflows/linux-distro-matrix.yml
@@ -1,0 +1,162 @@
+# Copyright (c) 2026 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+# Compatibility matrix: bazel build //src/Service:OrbitService inside a
+# real Docker userspace for every listed distro version.
+#
+# Triggers (there is NO pull_request or push trigger):
+#   - schedule: 07:00 UTC nightly, same as build-and-test.yml. A gate job
+#     no-ops when relevant paths are unchanged since the last completed
+#     run of this workflow on main.
+#   - workflow_dispatch: always runs. To test a PR, open Actions →
+#     linux-distro-matrix → Run workflow and pick the PR's branch.
+
+name: linux-distro-matrix
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+    inputs:
+      distro:
+        description: 'Limit to one distro (ubuntu, debian, fedora, rocky, almalinux, opensuse, alpine, amazonlinux, arch). Empty = every distro.'
+        required: false
+        default: ''
+        type: string
+      version:
+        description: 'Limit to one version (e.g. 22.04 or 44). Empty = every version of the selected distro(s).'
+        required: false
+        default: ''
+        type: string
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    name: gate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+      reason: ${{ steps.decide.outputs.reason }}
+      baseline: ${{ steps.decide.outputs.baseline }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      WORKFLOW_FILE: linux-distro-matrix.yml
+      GATE_BRANCH: main
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+      - name: Decide whether to run the matrix
+        id: decide
+        run: ci/linux/gate.sh '${{ github.event_name }}'
+
+  prepare:
+    name: prepare-matrix
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      cells: ${{ steps.filter.outputs.cells }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Filter versions
+        id: filter
+        env:
+          DISTRO_FILTER: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.distro || '' }}
+          VERSION_FILTER: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version || '' }}
+        run: |
+          cells="$(ci/linux/filter-matrix.sh "${DISTRO_FILTER}" "${VERSION_FILTER}")"
+          echo "cells=${cells}" >> "${GITHUB_OUTPUT}"
+          echo "Matrix cells: $(echo "${cells}" | jq 'length')"
+
+  build:
+    name: ${{ matrix.distro }} ${{ matrix.version }}
+    needs: [gate, prepare]
+    if: needs.gate.outputs.run == 'true' && needs.prepare.outputs.cells != '[]'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.prepare.outputs.cells) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+
+      - name: Mount Bazel cache
+        if: matrix.cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/orbit-ci/bazel-disk
+            ~/.cache/orbit-ci/bazel-repo
+            ~/.cache/orbit-ci/bazelisk
+          key: bazel-${{ matrix.distro }}-${{ matrix.version }}-${{ hashFiles('MODULE.bazel.lock', '.bazelversion') }}-${{ github.sha }}
+          restore-keys: |
+            bazel-${{ matrix.distro }}-${{ matrix.version }}-${{ hashFiles('MODULE.bazel.lock', '.bazelversion') }}-
+            bazel-${{ matrix.distro }}-${{ matrix.version }}-
+
+      - name: Build OrbitService in ${{ matrix.distro }} ${{ matrix.version }}
+        env:
+          DISTRO: ${{ matrix.distro }}
+          VERSION: ${{ matrix.version }}
+          CODENAME: ${{ matrix.codename }}
+          IMAGE: ${{ matrix.image }}
+          IMAGE_ALT: ${{ matrix.image_alt }}
+        run: ci/linux/run-job.sh
+
+      - name: Job summary
+        if: success() || failure()
+        run: |
+          file="ci-results/${{ matrix.distro }}-${{ matrix.version }}.json"
+          if [[ -f "${file}" ]]; then
+            echo "### ${{ matrix.distro }} ${{ matrix.version }}" >> "${GITHUB_STEP_SUMMARY}"
+            jq -r '"Status: **\(.status)**  ", "Error: \(.error)"' "${file}" >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Upload result
+        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: ci-result-${{ matrix.distro }}-${{ matrix.version }}
+          path: ci-results/${{ matrix.distro }}-${{ matrix.version }}.json
+          retention-days: 7
+          if-no-files-found: warn
+
+  summarize:
+    name: summarize
+    needs: [gate, prepare, build]
+    if: always()
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        if: needs.gate.outputs.run == 'true'
+
+      - name: Skipped (no relevant changes)
+        if: needs.gate.outputs.run != 'true'
+        run: |
+          echo "no changes since \`${{ needs.gate.outputs.baseline }}\`, skipped" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Download results
+        if: needs.gate.outputs.run == 'true'
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ci-result-*
+          path: ci-results
+          merge-multiple: true
+
+      - name: Write summary table
+        if: needs.gate.outputs.run == 'true'
+        run: ci/linux/summarize.sh ci-results

--- a/.github/workflows/linux-distro-matrix.yml
+++ b/.github/workflows/linux-distro-matrix.yml
@@ -143,8 +143,13 @@ jobs:
       - uses: actions/checkout@v4
         if: needs.gate.outputs.run == 'true'
 
+      - name: Gate failed
+        if: needs.gate.result != 'success'
+        run: |
+          echo "Gate job failed; matrix was not started." >> "${GITHUB_STEP_SUMMARY}"
+
       - name: Skipped (no relevant changes)
-        if: needs.gate.outputs.run != 'true'
+        if: needs.gate.result == 'success' && needs.gate.outputs.run != 'true'
         run: |
           echo "no changes since \`${{ needs.gate.outputs.baseline }}\`, skipped" >> "${GITHUB_STEP_SUMMARY}"
 

--- a/ci/linux/Dockerfile
+++ b/ci/linux/Dockerfile
@@ -1,0 +1,13 @@
+# Copyright (c) 2026 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+# Thin wrapper around an official (or fallback) distro image. Packages and
+# Bazel are installed at run time so a missing compiler / too-old glibc / no
+# Bazel shows up as a failed job with a log, not a silent matrix skip.
+
+ARG IMAGE=ubuntu:24.04
+FROM ${IMAGE}
+
+LABEL org.opencontainers.image.source="https://github.com/pierricgimmig/orbit"
+LABEL orbit.ci="linux-distro-matrix"

--- a/ci/linux/Dockerfile.ubuntu-archive
+++ b/ci/linux/Dockerfile.ubuntu-archive
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+# Materialize an Ubuntu userspace when Docker Hub no longer has ubuntu:YY.MM.
+# Debootstrap from old-releases.ubuntu.com (or archive.ubuntu.com).
+
+FROM ubuntu:24.04 AS bootstrap
+
+ARG DEBIAN_FRONTEND=noninteractive
+ARG SUITE=cosmic
+ARG MIRROR=http://old-releases.ubuntu.com/ubuntu
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        debootstrap \
+        ca-certificates \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN debootstrap --variant=minbase --arch=amd64 --no-check-gpg \
+        "${SUITE}" /rootfs "${MIRROR}"
+
+FROM scratch
+COPY --from=bootstrap /rootfs /
+ENV DEBIAN_FRONTEND=noninteractive
+CMD ["/bin/bash"]

--- a/ci/linux/filter-matrix.sh
+++ b/ci/linux/filter-matrix.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+# Print a compact JSON array of versions.json entries, optionally limited to
+# one distro and/or one version. Empty filters mean "everything".
+
+set -euo pipefail
+
+DISTRO_FILTER="${1:-}"
+VERSION_FILTER="${2:-}"
+FILE="${3:-ci/linux/versions.json}"
+
+jq -c --arg d "${DISTRO_FILTER}" --arg v "${VERSION_FILTER}" '
+  map(select(
+    ($d == "" or .distro == $d) and
+    ($v == "" or .version == $v)
+  ))
+' "${FILE}"

--- a/ci/linux/gate.sh
+++ b/ci/linux/gate.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+# Decide whether the nightly matrix should run.
+#
+# workflow_dispatch always builds.
+# schedule compares the current tree to the last completed run of this
+# workflow on main. A red matrix still counts as a baseline: many cells are
+# expected to fail, and nightly must no-op unless relevant files changed.
+
+set -euo pipefail
+
+EVENT_NAME="${1:-${GITHUB_EVENT_NAME:-}}"
+OUTPUT="${GITHUB_OUTPUT:-/dev/stdout}"
+
+write() {
+  printf '%s\n' "$1" >> "${OUTPUT}"
+}
+
+summarize() {
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    printf '%s\n' "$1" >> "${GITHUB_STEP_SUMMARY}"
+  fi
+}
+
+if [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
+  echo "workflow_dispatch: always run the matrix"
+  write "run=true"
+  write "reason=workflow_dispatch"
+  write "baseline="
+  summarize "workflow_dispatch: running the matrix on this ref (change gate skipped)."
+  exit 0
+fi
+
+WORKFLOW_FILE="${WORKFLOW_FILE:-linux-distro-matrix.yml}"
+BRANCH="${GATE_BRANCH:-main}"
+CURRENT_SHA="${GITHUB_SHA:-$(git rev-parse HEAD)}"
+CURRENT_RUN="${GITHUB_RUN_ID:-}"
+
+PATHS=(
+  src
+  bazel
+  third_party
+  .bazelrc
+  .bazelversion
+  MODULE.bazel
+  MODULE.bazel.lock
+  ci/linux
+  .github/workflows/linux-distro-matrix.yml
+)
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh is not available; running the matrix"
+  write "run=true"
+  write "reason=gh-unavailable"
+  write "baseline="
+  summarize "gh unavailable; running the matrix."
+  exit 0
+fi
+
+# Last completed run on main, success or failure. Cancelled / skipped runs
+# are ignored. The current run never appears as completed, but filter it
+# anyway. Failures count so a red compatibility table does not force a
+# full re-run every night.
+runs_json="$(
+  gh run list \
+    --workflow "${WORKFLOW_FILE}" \
+    --branch "${BRANCH}" \
+    --limit 50 \
+    --json databaseId,headSha,conclusion,status,event
+)"
+
+last_sha="$(
+  jq -r --arg id "${CURRENT_RUN}" '
+    [
+      .[]
+      | select((.databaseId | tostring) != $id)
+      | select(.status == "completed")
+      | select(.conclusion == "success" or .conclusion == "failure")
+    ]
+    | .[0].headSha // empty
+  ' <<<"${runs_json}"
+)"
+
+if [[ -z "${last_sha}" ]]; then
+  echo "No previous completed run on ${BRANCH}; running the matrix (first night)"
+  write "run=true"
+  write "reason=no-previous-run"
+  write "baseline="
+  summarize "No previous completed run of this workflow on \`${BRANCH}\`; running the matrix (first night)."
+  exit 0
+fi
+
+if ! git cat-file -e "${last_sha}^{commit}" 2>/dev/null; then
+  echo "Baseline ${last_sha} is not in this clone; fetching"
+  if ! git fetch --depth=1 origin "${last_sha}"; then
+    echo "Cannot fetch baseline ${last_sha}; running the matrix"
+    write "run=true"
+    write "reason=missing-baseline"
+    write "baseline=${last_sha}"
+    summarize "Could not fetch baseline \`${last_sha}\`; running the matrix."
+    exit 0
+  fi
+fi
+
+changed="$(git diff --name-only "${last_sha}" "${CURRENT_SHA}" -- "${PATHS[@]}" || true)"
+
+if [[ -z "${changed}" ]]; then
+  echo "no changes since ${last_sha}, skipped"
+  write "run=false"
+  write "reason=no-changes"
+  write "baseline=${last_sha}"
+  summarize "no changes since \`${last_sha}\`, skipped"
+  exit 0
+fi
+
+echo "Relevant changes since ${last_sha}:"
+printf '%s\n' "${changed}"
+write "run=true"
+write "reason=changes"
+write "baseline=${last_sha}"
+{
+  echo "Relevant changes since \`${last_sha}\`; running the matrix."
+  echo
+  echo '```'
+  printf '%s\n' "${changed}"
+  echo '```'
+} | {
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    cat >> "${GITHUB_STEP_SUMMARY}"
+  else
+    cat
+  fi
+}

--- a/ci/linux/install-and-build.sh
+++ b/ci/linux/install-and-build.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+# Guest-side: install the minimum tools this userspace can offer, then
+# `bazel build //src/Service:OrbitService`. Failures must be loud.
+
+set -u
+
+export DEBIAN_FRONTEND=noninteractive
+export TZ=UTC
+export PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+
+if [[ -f /etc/os-release ]]; then
+  echo "=== /etc/os-release ==="
+  cat /etc/os-release
+  echo "======================="
+fi
+
+if command -v git >/dev/null 2>&1; then
+  git config --global --add safe.directory /workspace || true
+fi
+
+try_install() {
+  local mgr="$1"
+  shift
+  echo "Trying ${mgr}: $*"
+  if "$@"; then
+    echo "OK: ${mgr}"
+    return 0
+  fi
+  echo "WARN: ${mgr} failed"
+  return 1
+}
+
+rewrite_urls() {
+  local file="$1"
+  local mirror="$2"
+  local pattern="$3"
+  if [[ -f "${file}" ]]; then
+    sed -i "s|${pattern}|${mirror}|g" "${file}" || true
+  fi
+}
+
+fix_ubuntu_mirrors() {
+  local mirror="$1"
+  local files=(/etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources)
+  local f
+  for f in "${files[@]}"; do
+    rewrite_urls "${f}" "${mirror}" 'http://[^ ]*ubuntu.com/ubuntu'
+    rewrite_urls "${f}" "${mirror}" 'https://[^ ]*ubuntu.com/ubuntu'
+  done
+}
+
+fix_debian_archive() {
+  local code=""
+  if [[ -f /etc/os-release ]]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    code="${VERSION_CODENAME:-}"
+  fi
+  case "${code}" in
+    stretch|buster)
+      echo "deb http://archive.debian.org/debian ${code} main" > /etc/apt/sources.list
+      echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99archive
+      rm -f /etc/apt/sources.list.d/* || true
+      ;;
+  esac
+}
+
+install_apt() {
+  fix_debian_archive
+  if ! apt-get update; then
+    echo "apt-get update failed; rewriting Ubuntu mirrors to old-releases"
+    fix_ubuntu_mirrors "http://old-releases.ubuntu.com/ubuntu"
+    if ! apt-get update; then
+      echo "old-releases failed; trying archive.ubuntu.com"
+      fix_ubuntu_mirrors "http://archive.ubuntu.com/ubuntu"
+      apt-get update || echo "WARN: apt-get update still failing"
+    fi
+  fi
+  local pkg
+  for pkg in ca-certificates curl wget git gcc g++ python3 unzip zip findutils; do
+    try_install "apt ${pkg}" apt-get install -y --no-install-recommends "${pkg}" || true
+  done
+}
+
+install_dnf_yum() {
+  if command -v dnf >/dev/null 2>&1; then
+    dnf -y update --refresh || true
+    try_install dnf dnf install -y gcc gcc-c++ python3 git curl ca-certificates unzip zip findutils || \
+      try_install dnf-minimal dnf install -y gcc gcc-c++ python3 git curl ca-certificates unzip zip || true
+  elif command -v yum >/dev/null 2>&1; then
+    yum -y update || true
+    try_install yum yum install -y gcc gcc-c++ python3 git curl ca-certificates unzip zip findutils || true
+  else
+    echo "WARN: no dnf/yum"
+  fi
+}
+
+install_zypper() {
+  zypper --non-interactive refresh || true
+  try_install zypper zypper --non-interactive install -y \
+    gcc gcc-c++ python3 git curl ca-certificates unzip zip findutils || true
+}
+
+install_apk() {
+  apk update || true
+  try_install apk apk add --no-cache \
+    bash gcc g++ python3 git curl ca-certificates unzip zip || true
+}
+
+install_pacman() {
+  pacman -Syu --noconfirm || true
+  try_install pacman pacman -S --noconfirm \
+    gcc python git curl unzip zip ca-certificates || true
+}
+
+if command -v apt-get >/dev/null 2>&1; then
+  install_apt
+elif command -v dnf >/dev/null 2>&1 || command -v yum >/dev/null 2>&1; then
+  install_dnf_yum
+elif command -v zypper >/dev/null 2>&1; then
+  install_zypper
+elif command -v apk >/dev/null 2>&1; then
+  install_apk
+elif command -v pacman >/dev/null 2>&1; then
+  install_pacman
+else
+  echo "WARN: no known package manager"
+fi
+
+if ! command -v gcc >/dev/null 2>&1 && ! command -v cc >/dev/null 2>&1 && ! command -v g++ >/dev/null 2>&1; then
+  echo "ERROR: missing compiler: gcc/g++/cc not installed"
+fi
+
+if [[ -f /workspace/.bazelversion ]]; then
+  export USE_BAZEL_VERSION
+  USE_BAZEL_VERSION="$(tr -d '[:space:]' < /workspace/.bazelversion)"
+fi
+
+if ! command -v bazel >/dev/null 2>&1; then
+  echo "ERROR: no Bazel: bazelisk is not on PATH"
+  exit 1
+fi
+
+if ! bazel version; then
+  echo "ERROR: no Bazel: bazelisk/bazel cannot run on this userspace (too-old glibc or incompatible binary)"
+  exit 1
+fi
+
+cat > /tmp/ci.bazelrc <<'EOF'
+common --announce_rc
+common --color=no
+common --curses=no
+build --spawn_strategy=standalone
+build --genrule_strategy=standalone
+build --disk_cache=/cache/bazel-disk
+build --repository_cache=/cache/bazel-repo
+build --keep_going
+EOF
+
+echo "=== bazel build //src/Service:OrbitService ==="
+bazel --bazelrc=/tmp/ci.bazelrc build //src/Service:OrbitService

--- a/ci/linux/run-job.sh
+++ b/ci/linux/run-job.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+# Host-side driver: materialize a Docker image for one distro version, run
+# install-and-build.sh inside it, and write ci-results/<distro>-<version>.json.
+
+set -u
+
+DISTRO="${DISTRO:?DISTRO is required}"
+VERSION="${VERSION:?VERSION is required}"
+CODENAME="${CODENAME:-}"
+IMAGE="${IMAGE:?IMAGE is required}"
+IMAGE_ALT="${IMAGE_ALT:-}"
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TAG="orbit-ci:${DISTRO}-${VERSION}"
+RESULT_DIR="${ROOT}/ci-results"
+RESULT_FILE="${RESULT_DIR}/${DISTRO}-${VERSION}.json"
+LOG_FILE="${RESULT_DIR}/${DISTRO}-${VERSION}.log"
+CACHE_DIR="${HOME}/.cache/orbit-ci"
+BAZELISK="${CACHE_DIR}/bazelisk-linux-amd64"
+
+mkdir -p "${RESULT_DIR}" "${CACHE_DIR}/bazel-disk" "${CACHE_DIR}/bazel-repo" "${CACHE_DIR}/bazelisk"
+
+write_result() {
+  local status="$1"
+  local error="$2"
+  jq -n \
+    --arg distro "${DISTRO}" \
+    --arg version "${VERSION}" \
+    --arg codename "${CODENAME}" \
+    --arg status "${status}" \
+    --arg error "${error}" \
+    '{distro:$distro,version:$version,codename:$codename,status:$status,error:$error}' \
+    > "${RESULT_FILE}"
+}
+
+first_useful_error() {
+  local log="$1"
+  local line=""
+  if [[ -f "${log}" ]]; then
+    line="$(
+      grep -E -i \
+        'no image:|ERROR: |error: |FATAL: |GLIBC_[0-9]|missing compiler|no Bazel|cannot execute|not found|debootstrap' \
+        "${log}" \
+        | grep -v -E '^(Get:|Hit:|Ign:|Fetched |Reading package|Selecting previously|Preparing to unpack|Unpacking |Setting up )' \
+        | head -n 1 || true
+    )"
+    if [[ -z "${line}" ]]; then
+      line="$(grep -E -i 'error|fail|fatal' "${log}" | tail -n 1 || true)"
+    fi
+  fi
+  if [[ -z "${line}" ]]; then
+    line="unknown failure"
+  fi
+  printf '%s' "${line}" | tr '\n' ' ' | head -c 240
+}
+
+trap 'if [[ ! -f "${RESULT_FILE}" ]]; then write_result fail "script aborted before writing a result"; fi' EXIT
+
+try_build_from() {
+  local from_image="$1"
+  echo "Building wrapper FROM ${from_image}"
+  docker build --pull --platform linux/amd64 \
+    -f "${ROOT}/ci/linux/Dockerfile" \
+    --build-arg "IMAGE=${from_image}" \
+    -t "${TAG}" \
+    "${ROOT}/ci/linux"
+}
+
+try_ubuntu_archive() {
+  local mirror="$1"
+  echo "Debootstrapping Ubuntu ${CODENAME} from ${mirror}"
+  docker build --platform linux/amd64 \
+    -f "${ROOT}/ci/linux/Dockerfile.ubuntu-archive" \
+    --build-arg "SUITE=${CODENAME}" \
+    --build-arg "MIRROR=${mirror}" \
+    -t "${TAG}" \
+    "${ROOT}/ci/linux"
+}
+
+materialize() {
+  if try_build_from "${IMAGE}"; then
+    return 0
+  fi
+  echo "Primary image ${IMAGE} failed"
+  if [[ -n "${IMAGE_ALT}" ]]; then
+    if try_build_from "${IMAGE_ALT}"; then
+      return 0
+    fi
+    echo "Fallback image ${IMAGE_ALT} failed"
+  fi
+  if [[ "${DISTRO}" == "ubuntu" && -n "${CODENAME}" ]]; then
+    if try_ubuntu_archive "http://old-releases.ubuntu.com/ubuntu"; then
+      return 0
+    fi
+    if try_ubuntu_archive "http://archive.ubuntu.com/ubuntu"; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+if ! materialize >"${LOG_FILE}" 2>&1; then
+  cat "${LOG_FILE}"
+  err="no image: cannot materialize ${DISTRO} ${VERSION} (${IMAGE})"
+  echo "${err}"
+  write_result fail "${err}"
+  exit 1
+fi
+cat "${LOG_FILE}"
+
+if [[ ! -x "${BAZELISK}" ]]; then
+  echo "Downloading bazelisk"
+  if ! curl -fsSL -o "${BAZELISK}" \
+      "https://github.com/bazelbuild/bazelisk/releases/download/v1.26.1/bazelisk-linux-amd64"; then
+    err="no Bazel: failed to download bazelisk on the runner"
+    echo "${err}"
+    write_result fail "${err}"
+    exit 1
+  fi
+  chmod +x "${BAZELISK}"
+fi
+
+echo "Running ${DISTRO} ${VERSION} (${CODENAME}) in ${TAG}"
+set +e
+docker run --rm --privileged \
+  --network host \
+  -v "${ROOT}:/workspace:rw" \
+  -v "${CACHE_DIR}/bazel-disk:/cache/bazel-disk:rw" \
+  -v "${CACHE_DIR}/bazel-repo:/cache/bazel-repo:rw" \
+  -v "${CACHE_DIR}/bazelisk:/root/.cache/bazelisk:rw" \
+  -v "${BAZELISK}:/usr/local/bin/bazel:ro" \
+  -e "DISTRO=${DISTRO}" \
+  -e "VERSION=${VERSION}" \
+  -e "CODENAME=${CODENAME}" \
+  -w /workspace \
+  "${TAG}" \
+  /bin/sh -c '
+    if ! command -v bash >/dev/null 2>&1; then
+      if command -v apk >/dev/null 2>&1; then
+        apk add --no-cache bash >/tmp/apk-bash.log 2>&1 || true
+      fi
+    fi
+    if command -v bash >/dev/null 2>&1; then
+      exec bash /workspace/ci/linux/install-and-build.sh
+    fi
+    exec /bin/sh /workspace/ci/linux/install-and-build.sh
+  ' >"${LOG_FILE}" 2>&1
+rc=$?
+set -e
+cat "${LOG_FILE}"
+
+if [[ ${rc} -eq 0 ]]; then
+  write_result pass ""
+  exit 0
+fi
+
+write_result fail "$(first_useful_error "${LOG_FILE}")"
+exit "${rc}"

--- a/ci/linux/summarize.sh
+++ b/ci/linux/summarize.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The Orbit Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+# Write a GitHub Step Summary table from ci-results/*.json.
+
+set -euo pipefail
+
+RESULTS_DIR="${1:-ci-results}"
+OUT="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+escape() {
+  printf '%s' "$1" | tr '\n' ' ' | sed 's/|/\\|/g'
+}
+
+if [[ ! -d "${RESULTS_DIR}" ]]; then
+  echo "No result artifacts." >> "${OUT}"
+  exit 0
+fi
+
+# download-artifact with merge-multiple may nest files.
+mapfile -t files < <(find "${RESULTS_DIR}" -name '*.json' -type f | sort)
+
+if [[ ${#files[@]} -eq 0 ]]; then
+  echo "No result JSON files." >> "${OUT}"
+  exit 0
+fi
+
+{
+  echo '| Distro | Version | Codename | Status | Error |'
+  echo '| --- | --- | --- | --- | --- |'
+  for f in "${files[@]}"; do
+    distro="$(jq -r '.distro // ""' "${f}")"
+    version="$(jq -r '.version // ""' "${f}")"
+    codename="$(jq -r '.codename // ""' "${f}")"
+    status="$(jq -r '.status // ""' "${f}")"
+    error="$(jq -r '.error // ""' "${f}")"
+    printf '| %s | %s | %s | %s | %s |\n' \
+      "$(escape "${distro}")" \
+      "$(escape "${version}")" \
+      "$(escape "${codename}")" \
+      "$(escape "${status}")" \
+      "$(escape "${error}")"
+  done
+} >> "${OUT}"

--- a/ci/linux/versions.json
+++ b/ci/linux/versions.json
@@ -1,0 +1,594 @@
+[
+  {
+    "distro": "ubuntu",
+    "version": "18.04",
+    "codename": "bionic",
+    "image": "ubuntu:18.04",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "ubuntu",
+    "version": "18.10",
+    "codename": "cosmic",
+    "image": "ubuntu:18.10",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "ubuntu",
+    "version": "19.04",
+    "codename": "disco",
+    "image": "ubuntu:19.04",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "ubuntu",
+    "version": "19.10",
+    "codename": "eoan",
+    "image": "ubuntu:19.10",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "ubuntu",
+    "version": "20.04",
+    "codename": "focal",
+    "image": "ubuntu:20.04",
+    "image_alt": "",
+    "cache": true
+  },
+  {
+    "distro": "ubuntu",
+    "version": "20.10",
+    "codename": "groovy",
+    "image": "ubuntu:20.10",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "ubuntu",
+    "version": "21.04",
+    "codename": "hirsute",
+    "image": "ubuntu:21.04",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "ubuntu",
+    "version": "21.10",
+    "codename": "impish",
+    "image": "ubuntu:21.10",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "ubuntu",
+    "version": "22.04",
+    "codename": "jammy",
+    "image": "ubuntu:22.04",
+    "image_alt": "",
+    "cache": true
+  },
+  {
+    "distro": "ubuntu",
+    "version": "22.10",
+    "codename": "kinetic",
+    "image": "ubuntu:22.10",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "ubuntu",
+    "version": "23.04",
+    "codename": "lunar",
+    "image": "ubuntu:23.04",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "ubuntu",
+    "version": "23.10",
+    "codename": "mantic",
+    "image": "ubuntu:23.10",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "ubuntu",
+    "version": "24.04",
+    "codename": "noble",
+    "image": "ubuntu:24.04",
+    "image_alt": "",
+    "cache": true
+  },
+  {
+    "distro": "ubuntu",
+    "version": "24.10",
+    "codename": "oracular",
+    "image": "ubuntu:24.10",
+    "image_alt": "",
+    "cache": true
+  },
+  {
+    "distro": "ubuntu",
+    "version": "25.04",
+    "codename": "plucky",
+    "image": "ubuntu:25.04",
+    "image_alt": "",
+    "cache": true
+  },
+  {
+    "distro": "ubuntu",
+    "version": "25.10",
+    "codename": "questing",
+    "image": "ubuntu:25.10",
+    "image_alt": "",
+    "cache": true
+  },
+  {
+    "distro": "ubuntu",
+    "version": "26.04",
+    "codename": "resolute",
+    "image": "ubuntu:26.04",
+    "image_alt": "",
+    "cache": true
+  },
+  {
+    "distro": "debian",
+    "version": "9",
+    "codename": "stretch",
+    "image": "debian:9",
+    "image_alt": "debian:stretch",
+    "cache": false
+  },
+  {
+    "distro": "debian",
+    "version": "10",
+    "codename": "buster",
+    "image": "debian:10",
+    "image_alt": "debian:buster",
+    "cache": false
+  },
+  {
+    "distro": "debian",
+    "version": "11",
+    "codename": "bullseye",
+    "image": "debian:11",
+    "image_alt": "debian:bullseye",
+    "cache": false
+  },
+  {
+    "distro": "debian",
+    "version": "12",
+    "codename": "bookworm",
+    "image": "debian:12",
+    "image_alt": "debian:bookworm",
+    "cache": true
+  },
+  {
+    "distro": "debian",
+    "version": "13",
+    "codename": "trixie",
+    "image": "debian:13",
+    "image_alt": "debian:trixie",
+    "cache": true
+  },
+  {
+    "distro": "fedora",
+    "version": "28",
+    "codename": "f28",
+    "image": "fedora:28",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "fedora",
+    "version": "29",
+    "codename": "f29",
+    "image": "fedora:29",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "fedora",
+    "version": "30",
+    "codename": "f30",
+    "image": "fedora:30",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "fedora",
+    "version": "31",
+    "codename": "f31",
+    "image": "fedora:31",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "fedora",
+    "version": "32",
+    "codename": "f32",
+    "image": "fedora:32",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "fedora",
+    "version": "33",
+    "codename": "f33",
+    "image": "fedora:33",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "fedora",
+    "version": "34",
+    "codename": "f34",
+    "image": "fedora:34",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "fedora",
+    "version": "35",
+    "codename": "f35",
+    "image": "fedora:35",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "fedora",
+    "version": "36",
+    "codename": "f36",
+    "image": "fedora:36",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "fedora",
+    "version": "37",
+    "codename": "f37",
+    "image": "fedora:37",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "fedora",
+    "version": "38",
+    "codename": "f38",
+    "image": "fedora:38",
+    "image_alt": "",
+    "cache": true
+  },
+  {
+    "distro": "fedora",
+    "version": "39",
+    "codename": "f39",
+    "image": "fedora:39",
+    "image_alt": "",
+    "cache": true
+  },
+  {
+    "distro": "fedora",
+    "version": "40",
+    "codename": "f40",
+    "image": "fedora:40",
+    "image_alt": "",
+    "cache": true
+  },
+  {
+    "distro": "fedora",
+    "version": "41",
+    "codename": "f41",
+    "image": "fedora:41",
+    "image_alt": "",
+    "cache": true
+  },
+  {
+    "distro": "fedora",
+    "version": "42",
+    "codename": "f42",
+    "image": "fedora:42",
+    "image_alt": "",
+    "cache": true
+  },
+  {
+    "distro": "fedora",
+    "version": "43",
+    "codename": "f43",
+    "image": "fedora:43",
+    "image_alt": "",
+    "cache": true
+  },
+  {
+    "distro": "fedora",
+    "version": "44",
+    "codename": "f44",
+    "image": "fedora:44",
+    "image_alt": "",
+    "cache": true
+  },
+  {
+    "distro": "rocky",
+    "version": "8",
+    "codename": "greenobsidian",
+    "image": "rockylinux:8",
+    "image_alt": "rockylinux/rockylinux:8",
+    "cache": false
+  },
+  {
+    "distro": "rocky",
+    "version": "9",
+    "codename": "blueonyx",
+    "image": "rockylinux:9",
+    "image_alt": "rockylinux/rockylinux:9",
+    "cache": true
+  },
+  {
+    "distro": "rocky",
+    "version": "10",
+    "codename": "redquartz",
+    "image": "rockylinux/rockylinux:10",
+    "image_alt": "rockylinux:10",
+    "cache": true
+  },
+  {
+    "distro": "almalinux",
+    "version": "8",
+    "codename": "",
+    "image": "almalinux:8",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "almalinux",
+    "version": "9",
+    "codename": "",
+    "image": "almalinux:9",
+    "image_alt": "",
+    "cache": true
+  },
+  {
+    "distro": "almalinux",
+    "version": "10",
+    "codename": "",
+    "image": "almalinux:10",
+    "image_alt": "",
+    "cache": true
+  },
+  {
+    "distro": "opensuse",
+    "version": "15.0",
+    "codename": "leap15.0",
+    "image": "opensuse/leap:15.0",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "opensuse",
+    "version": "15.1",
+    "codename": "leap15.1",
+    "image": "opensuse/leap:15.1",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "opensuse",
+    "version": "15.2",
+    "codename": "leap15.2",
+    "image": "opensuse/leap:15.2",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "opensuse",
+    "version": "15.3",
+    "codename": "leap15.3",
+    "image": "opensuse/leap:15.3",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "opensuse",
+    "version": "15.4",
+    "codename": "leap15.4",
+    "image": "opensuse/leap:15.4",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "opensuse",
+    "version": "15.5",
+    "codename": "leap15.5",
+    "image": "opensuse/leap:15.5",
+    "image_alt": "",
+    "cache": true
+  },
+  {
+    "distro": "opensuse",
+    "version": "15.6",
+    "codename": "leap15.6",
+    "image": "opensuse/leap:15.6",
+    "image_alt": "",
+    "cache": true
+  },
+  {
+    "distro": "opensuse",
+    "version": "16.0",
+    "codename": "leap16.0",
+    "image": "opensuse/leap:16.0",
+    "image_alt": "",
+    "cache": true
+  },
+  {
+    "distro": "opensuse",
+    "version": "tumbleweed",
+    "codename": "tumbleweed",
+    "image": "opensuse/tumbleweed:latest",
+    "image_alt": "",
+    "cache": true
+  },
+  {
+    "distro": "alpine",
+    "version": "3.8",
+    "codename": "v3.8",
+    "image": "alpine:3.8",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "alpine",
+    "version": "3.9",
+    "codename": "v3.9",
+    "image": "alpine:3.9",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "alpine",
+    "version": "3.10",
+    "codename": "v3.10",
+    "image": "alpine:3.10",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "alpine",
+    "version": "3.11",
+    "codename": "v3.11",
+    "image": "alpine:3.11",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "alpine",
+    "version": "3.12",
+    "codename": "v3.12",
+    "image": "alpine:3.12",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "alpine",
+    "version": "3.13",
+    "codename": "v3.13",
+    "image": "alpine:3.13",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "alpine",
+    "version": "3.14",
+    "codename": "v3.14",
+    "image": "alpine:3.14",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "alpine",
+    "version": "3.15",
+    "codename": "v3.15",
+    "image": "alpine:3.15",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "alpine",
+    "version": "3.16",
+    "codename": "v3.16",
+    "image": "alpine:3.16",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "alpine",
+    "version": "3.17",
+    "codename": "v3.17",
+    "image": "alpine:3.17",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "alpine",
+    "version": "3.18",
+    "codename": "v3.18",
+    "image": "alpine:3.18",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "alpine",
+    "version": "3.19",
+    "codename": "v3.19",
+    "image": "alpine:3.19",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "alpine",
+    "version": "3.20",
+    "codename": "v3.20",
+    "image": "alpine:3.20",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "alpine",
+    "version": "3.21",
+    "codename": "v3.21",
+    "image": "alpine:3.21",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "alpine",
+    "version": "3.22",
+    "codename": "v3.22",
+    "image": "alpine:3.22",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "alpine",
+    "version": "3.23",
+    "codename": "v3.23",
+    "image": "alpine:3.23",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "alpine",
+    "version": "3.24",
+    "codename": "v3.24",
+    "image": "alpine:3.24",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "amazonlinux",
+    "version": "2",
+    "codename": "amzn2",
+    "image": "amazonlinux:2",
+    "image_alt": "",
+    "cache": false
+  },
+  {
+    "distro": "amazonlinux",
+    "version": "2023",
+    "codename": "amzn2023",
+    "image": "amazonlinux:2023",
+    "image_alt": "",
+    "cache": true
+  },
+  {
+    "distro": "arch",
+    "version": "rolling",
+    "codename": "rolling",
+    "image": "archlinux:latest",
+    "image_alt": "",
+    "cache": true
+  }
+]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a compatibility workflow that tries `bazel build //src/Service:OrbitService` inside a real Docker userspace for every listed Linux release from the 2018 / Ubuntu 18.04 era through 2026-08-25.

This is CI-only. Application source is unchanged. Not a required status check — honest red/green per version is the point.

## Triggers (no `pull_request`, no `push`)

- **Nightly:** `cron: '0 7 * * *'` (07:00 UTC, same as `build-and-test.yml`), including weekends.
- **Manual:** `workflow_dispatch` on any ref. To run against a PR, open **Actions → linux-distro-matrix → Run workflow** and pick the PR’s branch. Leave the optional distro/version inputs empty to run everything.

A `ci:distro-matrix` label trigger is not included.

## Nightly change gate

On `schedule` only, a cheap **gate** job compares relevant paths on `main` to the last **completed** run of this workflow on `main` (`gh run list` / `GITHUB_TOKEN`):

`src/`, `bazel/`, `third_party/`, `.bazelrc`, `.bazelversion`, `MODULE.bazel`, `MODULE.bazel.lock`, `ci/linux/`, and this workflow file.

- No previous completed run → run the matrix (first night).
- No commits touching those paths since that SHA → skip the matrix. The workflow succeeds and the step summary says `no changes since <sha>, skipped`.
- `workflow_dispatch` skips the gate and always builds.

A completed red matrix still counts as a baseline. Many cells are expected to fail (too-old glibc, musl, missing Bazel, vanished Hub tags). If the gate only accepted a fully green run, nightly would never no-op.

Matrix jobs `needs` the gate and start only when it says go.

## Matrix (74 Docker jobs, `fail-fast: false`)

Listed in `ci/linux/versions.json`. Official Hub tags preferred. If a tag is gone, Ubuntu falls back to debootstrap from `old-releases.ubuntu.com` / `archive.ubuntu.com`. Other distros fail with a clear `no image:` line rather than being omitted.

| Distro | Versions |
| --- | --- |
| Ubuntu | 18.04, 18.10, 19.04, 19.10, 20.04, 20.10, 21.04, 21.10, 22.04, 22.10, 23.04, 23.10, 24.04, 24.10, 25.04, 25.10, 26.04 (not 26.10) |
| Debian | 9 stretch, 10 buster, 11 bullseye, 12 bookworm, 13 trixie (14/forky not released) |
| Fedora | 28 through 44 (45 not released) |
| Rocky Linux | 8, 9, 10 |
| AlmaLinux | 8, 9, 10 |
| openSUSE | Leap 15.0–15.6, Leap 16.0, plus one Tumbleweed rolling job |
| Alpine | 3.8 through 3.24 |
| Amazon Linux | 2 and 2023 (no 2025/2026 official image) |
| Arch Linux | one job on `archlinux:latest` |

Each cell: start the matching container, install whatever compiler/tools that release can offer, run Bazelisk + `bazel build //src/Service:OrbitService`. If Bazel cannot even install, the job still runs and fails with a log (`missing compiler` / too-old glibc / `no Bazel`), not a silent skip.

Bazel disk/repo cache is enabled only on recent releases where it can help.

## Summary

The **summarize** job writes a GitHub Step Summary table: distro, version, codename, pass/fail, first useful error line.

`permissions: read-all` and `cancel-in-progress` concurrency match `build-and-test.yml`. Existing host `build-and-test.yml` jobs are untouched.

## How to run this on a PR branch

This workflow will **not** start from opening or updating a pull request. After the PR exists:

1. Actions → **linux-distro-matrix** → **Run workflow**
2. Select the PR branch (`cursor/linux-distro-matrix-68f7` or later)
3. Optionally set `distro` / `version` to shrink the matrix; leave both empty for all 74 cells

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d03c8a4-f5c8-4e7f-86ae-d0c5bd6068f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d03c8a4-f5c8-4e7f-86ae-d0c5bd6068f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

