### PR TITLE
CI: bump upload-artifact off deprecated v3 so Scorecards can run

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
       - name: Install dependencies
@@ -32,7 +32,7 @@ jobs:
         run: ./contrib/scripts/check-clang-format.sh
         shell: bash
       - name: 'Upload clang-format diff'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: clang_format_diff
@@ -41,7 +41,7 @@ jobs:
       - run: echo "${{ github.event.number }}" > pr_number.txt
         if: success() || failure()
       - name: 'Upload PR number'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: pr_number
@@ -52,14 +52,14 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: '0'
     - name: Check license headers
       run: ./contrib/scripts/check-license-headers.sh
       shell: bash
     - name: 'Upload missing license headers'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
         name: missing_license_headers

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -32,12 +32,12 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@99c53751e09b9529366343771cc321ec74e9bd3d # v2.0.6
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif
@@ -59,7 +59,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: SARIF file
           path: results.sarif
@@ -67,6 +67,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@807578363a7869ca324a79039e6db9c843e0e100 # v2.1.27
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
GitHub now refuses to start jobs that pin `actions/upload-artifact` v3, which is why [the latest completed Scorecards run](https://github.com/pierricgimmig/orbit/actions/runs/32913220017) failed at **Set up job** in ~7s:

> This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: 3cea5372237819ed00197afe530f5a7ea3e805c8` (v3.1.0).

This is a CI-only follow-up off `main` (PR 24 / `live-viewer` is not touched).

## Changes

**`.github/workflows/scorecards.yml`** — SHA pins refreshed to current maintained versions:

| Action | Was | Now |
|---|---|---|
| `actions/upload-artifact` | v3.1.0 | v4.6.2 |
| `actions/checkout` | v3.1.0 | v7.0.1 (official scorecard template) |
| `ossf/scorecard-action` | v2.0.6 | v2.4.4 (official scorecard template) |
| `github/codeql-action/upload-sarif` | v2.1.27 | v4.37.4 (official scorecard template) |

`upload-artifact` is pinned to the latest v4 SHA (`ea165f8d65b6e75b540449e92b4886f43607fa02`). The other three match [ossf/scorecard's current analysis workflow](https://github.com/ossf/scorecard/blob/main/.github/workflows/scorecard-analysis.yml).

**`.github/workflows/checks.yml`** — `actions/checkout@v3` → `@v4` and `actions/upload-artifact@v3` → `@v4` (three uploads), matching `build-and-test.yml` / `linux-distro-matrix.yml`.

No remaining `upload-artifact@v3` (or the v3 SHA) under `.github/workflows`. Application source is unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b21a96e-aa87-44a5-a401-cb18fbfd96fa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b21a96e-aa87-44a5-a401-cb18fbfd96fa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

