### PR TITLE
CI: stop linux-distro-matrix dying on a nonexistent bazelisk tag

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
       - name: Install dependencies
@@ -32,7 +32,7 @@ jobs:
         run: ./contrib/scripts/check-clang-format.sh
         shell: bash
       - name: 'Upload clang-format diff'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: clang_format_diff
@@ -41,7 +41,7 @@ jobs:
       - run: echo "${{ github.event.number }}" > pr_number.txt
         if: success() || failure()
       - name: 'Upload PR number'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: pr_number
@@ -52,14 +52,14 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: '0'
     - name: Check license headers
       run: ./contrib/scripts/check-license-headers.sh
       shell: bash
     - name: 'Upload missing license headers'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
         name: missing_license_headers

--- a/.github/workflows/linux-distro-matrix.yml
+++ b/.github/workflows/linux-distro-matrix.yml
@@ -93,6 +93,17 @@ jobs:
         with:
           fetch-depth: '0'
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Docker diagnostics
+        run: |
+          if ! docker info >/dev/null 2>&1; then
+            sudo service docker start || sudo systemctl start docker || true
+          fi
+          docker version
+          docker info
+
       - name: Mount Bazel cache
         if: matrix.cache
         uses: actions/cache@v4
@@ -101,6 +112,7 @@ jobs:
             ~/.cache/orbit-ci/bazel-disk
             ~/.cache/orbit-ci/bazel-repo
             ~/.cache/orbit-ci/bazelisk
+            ~/.cache/orbit-ci/bazelisk-linux-amd64
           key: bazel-${{ matrix.distro }}-${{ matrix.version }}-${{ hashFiles('MODULE.bazel.lock', '.bazelversion') }}-${{ github.sha }}
           restore-keys: |
             bazel-${{ matrix.distro }}-${{ matrix.version }}-${{ hashFiles('MODULE.bazel.lock', '.bazelversion') }}-

--- a/ci/linux/run-job.sh
+++ b/ci/linux/run-job.sh
@@ -37,19 +37,29 @@ write_result() {
     > "${RESULT_FILE}"
 }
 
-first_useful_error() {
+# Pick a compact, human-readable line from a build/materialize log.
+# $2 is "first" (guest compile) or "last" (docker/debootstrap retries).
+useful_error() {
   local log="$1"
+  local which="${2:-first}"
+  local pick="head"
+  if [[ "${which}" == "last" ]]; then
+    pick="tail"
+  fi
   local line=""
   if [[ -f "${log}" ]]; then
     line="$(
       grep -E -i \
-        'no image:|ERROR: |error: |FATAL: |GLIBC_[0-9]|missing compiler|no Bazel|cannot execute|not found|debootstrap' \
+        'no image:|ERROR: |error: |FATAL: |GLIBC_[0-9]|missing compiler|no Bazel|cannot execute|not found|Cannot connect|debootstrap|failed to solve|permission denied' \
         "${log}" \
         | grep -v -E '^(Get:|Hit:|Ign:|Fetched |Reading package|Selecting previously|Preparing to unpack|Unpacking |Setting up )' \
-        | head -n 1 || true
+        | ${pick} -n 1 || true
     )"
     if [[ -z "${line}" ]]; then
       line="$(grep -E -i 'error|fail|fatal' "${log}" | tail -n 1 || true)"
+    fi
+    if [[ -z "${line}" ]]; then
+      line="$(grep -E -v '^[[:space:]]*$' "${log}" | tail -n 1 || true)"
     fi
   fi
   if [[ -z "${line}" ]]; then
@@ -58,7 +68,35 @@ first_useful_error() {
   printf '%s' "${line}" | tr '\n' ' ' | head -c 240
 }
 
+first_useful_error() {
+  useful_error "$1" first
+}
+
+last_useful_error() {
+  useful_error "$1" last
+}
+
+ensure_docker() {
+  echo "=== docker version ==="
+  if ! docker version; then
+    write_result fail "docker not available: docker version failed"
+    exit 1
+  fi
+  echo "=== docker info ==="
+  if ! docker info; then
+    echo "docker info failed; trying to start the daemon"
+    sudo service docker start 2>/dev/null || sudo systemctl start docker 2>/dev/null || true
+    if ! docker info; then
+      write_result fail "docker not available: docker info failed (daemon not running?)"
+      exit 1
+    fi
+  fi
+  echo "====================="
+}
+
 trap 'if [[ ! -f "${RESULT_FILE}" ]]; then write_result fail "script aborted before writing a result"; fi' EXIT
+
+ensure_docker
 
 try_build_from() {
   local from_image="$1"
@@ -105,18 +143,30 @@ materialize() {
 
 if ! materialize >"${LOG_FILE}" 2>&1; then
   cat "${LOG_FILE}"
-  err="no image: cannot materialize ${DISTRO} ${VERSION} (${IMAGE})"
+  detail="$(last_useful_error "${LOG_FILE}")"
+  err="no image: cannot materialize ${DISTRO} ${VERSION} (${IMAGE}): ${detail}"
   echo "${err}"
   write_result fail "${err}"
   exit 1
 fi
 cat "${LOG_FILE}"
 
+# v1.26.1 is not a bazelisk release (404). Pin a real tag; bazelisk then
+# downloads the Bazel in .bazelversion.
+BAZELISK_VERSION="v1.26.0"
+BAZELISK_URL="https://github.com/bazelbuild/bazelisk/releases/download/${BAZELISK_VERSION}/bazelisk-linux-amd64"
+
 if [[ ! -x "${BAZELISK}" ]]; then
-  echo "Downloading bazelisk"
-  if ! curl -fsSL -o "${BAZELISK}" \
-      "https://github.com/bazelbuild/bazelisk/releases/download/v1.26.1/bazelisk-linux-amd64"; then
-    err="no Bazel: failed to download bazelisk on the runner"
+  echo "Downloading bazelisk ${BAZELISK_VERSION}"
+  curl_err=""
+  if ! curl_err="$(curl -fsSL -o "${BAZELISK}" "${BAZELISK_URL}" 2>&1)"; then
+    err="no Bazel: failed to download bazelisk ${BAZELISK_VERSION} (${BAZELISK_URL}): ${curl_err}"
+    echo "${err}"
+    write_result fail "${err}"
+    exit 1
+  fi
+  if [[ "$(head -c 4 "${BAZELISK}")" != $'\x7fELF' ]]; then
+    err="no Bazel: downloaded bazelisk ${BAZELISK_VERSION} is not an ELF binary"
     echo "${err}"
     write_result fail "${err}"
     exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The first `workflow_dispatch` of `linux-distro-matrix` ([run 32914762583](https://github.com/pierricgimmig/orbit/actions/runs/32914762583), PR 24 merge on `main`) failed every one of the 74 cells in ~5s. That is a runner/script bug, not “old distros cannot compile Orbit”.

## What actually failed

Job logs (including `ubuntu 24.04`, `debian 12`, `fedora 44`, and old cells such as `debian 9`) all show the same sequence:

1. `docker build` of the thin wrapper **succeeded** (`naming to docker.io/library/orbit-ci:… done`).
2. `curl` of bazelisk **404’d**:
   ```
   Downloading bazelisk
   curl: (22) The requested URL returned error: 404
   no Bazel: failed to download bazelisk on the runner
   ```

`ci/linux/run-job.sh` pinned `https://github.com/bazelbuild/bazelisk/releases/download/v1.26.1/bazelisk-linux-amd64`. **v1.26.1 is not a bazelisk release** (tags jump `v1.26.0` → `v1.27.0`). The ~150-byte result JSON is that generic “no Bazel…” string, not the `no image: cannot materialize …` branch.

So current images never reached `install-and-build.sh` / Bazel.

## Fixes

- **Pin a real bazelisk tag** (`v1.26.0`) and reject a non-ELF download so a future HTML/404 cannot be chmod’d and mounted as `bazel`.
- **Stop swallowing the real error.** A failed `docker build` now appends the last useful docker/debootstrap line to the JSON `error` field (already printed in the job summary). A failed bazelisk download now includes the URL and the curl line (e.g. `404`).
- **Make the next runner failure obvious:** `docker/setup-buildx-action@v4`, start docker if `docker info` fails, and print `docker version` / `docker info` in the workflow and in `run-job.sh`.
- **Unblock this PR’s `checks` jobs:** GitHub refuses to start `check-clang-format` / `check-license-headers` while `.github/workflows/checks.yml` still pins `actions/upload-artifact@v3` on `main` ([example](https://github.com/pierricgimmig/orbit/actions/runs/32915391021/job/98017926625)). Copied PR 25’s `checkout@v3`→`@v4` and three `upload-artifact@v3`→`@v4` pins so those jobs can start before PR 25 merges. Scorecards is left to PR 25.

Expected-old-distro compile failures stay honest red (`fail-fast: false`, no `continue-on-error` on the matrix). The default `workflow_dispatch` matrix is unchanged.

## Success criterion

`ubuntu:24.04` / `debian:12` / `fedora:44` get past `materialize` and the host bazelisk download into `install-and-build.sh` / Bazel. A green 74/74 is **not** the goal.

Verified locally: `v1.26.1` → HTTP 404; `v1.26.0` → 302 + 5.9MB ELF; error extraction keeps the last docker/debootstrap line and the first guest-compile line. This environment has no Docker daemon, so the wrapper `docker build` was not re-run here.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a8c4a7b-2955-4389-a014-feaa9eb40255?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a8c4a7b-2955-4389-a014-feaa9eb40255&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

