### PR TITLE
CI: stream linux-distro-matrix guest logs live in Actions

### DIFF
--- a/ci/linux/run-job.sh
+++ b/ci/linux/run-job.sh
@@ -175,7 +175,11 @@ if [[ ! -x "${BAZELISK}" ]]; then
 fi
 
 echo "Running ${DISTRO} ${VERSION} (${CODENAME}) in ${TAG}"
+# Stream guest stdout/stderr into the workflow log as they happen, and keep a
+# copy for post-run error extraction. pipefail so docker's exit (not tee's)
+# is what we record.
 set +e
+set -o pipefail
 docker run --rm --privileged \
   --network host \
   -v "${ROOT}:/workspace:rw" \
@@ -198,10 +202,10 @@ docker run --rm --privileged \
       exec bash /workspace/ci/linux/install-and-build.sh
     fi
     exec /bin/sh /workspace/ci/linux/install-and-build.sh
-  ' >"${LOG_FILE}" 2>&1
+  ' 2>&1 | tee "${LOG_FILE}"
 rc=$?
+set +o pipefail
 set -e
-cat "${LOG_FILE}"
 
 if [[ ${rc} -eq 0 ]]; then
   write_result pass ""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`ci/linux/run-job.sh` ran the guest with `docker run … >"$LOG_FILE" 2>&1` and only `cat`’d the file after the container exited. GitHub Actions therefore sat on the host line `Running ${DISTRO} ${VERSION} … in orbit-ci:…` for the whole Bazel compile (10–60+ minutes) with no apt/Bazel progress. In-progress job logs are also 404 until the job completes, so the only way to see compile progress is to stream docker stdout/stderr to the workflow log as it happens.

## Change

Pipe `docker run` through `tee "$LOG_FILE"` so guest stdout+stderr appear incrementally in the Actions step log **and** still land in the log file used for:

- `first_useful_error` → JSON `error` field
- `ci-result-<distro>-<version>` artifact

`set -o pipefail` keeps docker’s exit status (a successful `tee` no longer hides a failed guest). The post-run `cat` is removed so the compile is not printed twice.

No matrix, trigger, Bazel/bazelisk, distro-list, or build-flag changes. `materialize` (`docker build`) is unchanged.

## How to verify

- `docker run` is no longer redirected with a silent `> file 2>&1`.
- A failing guest still produces a useful `error` string in the result JSON.
- Optional: `workflow_dispatch` one cell and confirm apt/bazelisk/Bazel lines show up before the job finishes.

## Local verification

This environment has no Docker daemon, so `docker` was mocked. `bash -n` is clean.

Fail path (`docker run` exit 17) streamed guest lines after `Running ubuntu 24.04 …` and still wrote a useful JSON error:

```
01:11:00.357 Running ubuntu 24.04 (noble) in orbit-ci:ubuntu-24.04
01:11:00.702 Get:1 http://archive.ubuntu.com/ubuntu noble InRelease [256 kB]
01:11:01.756 === bazel build //src/Service:OrbitService ===
01:11:02.458 ERROR: missing compiler: gcc/g++/cc not installed
```

```json
{"distro":"ubuntu","version":"24.04","codename":"noble","status":"fail","error":"ERROR: missing compiler: gcc/g++/cc not installed"}
```

Pass path: exit 0 and `{"status":"pass","error":""}`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-857e6521-c6e2-4afb-9df8-f1de033a58f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-857e6521-c6e2-4afb-9df8-f1de033a58f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

