### PR TITLE
CI: shrink linux-distro-matrix to green and easy-fix cells

### DIFF
--- a/ci/linux/install-and-build.sh
+++ b/ci/linux/install-and-build.sh
@@ -69,6 +69,16 @@ fix_debian_archive() {
   esac
 }
 
+# Minimal EL/Amazon images ship curl-minimal. Installing the full `curl`
+# package conflicts with it and dnf aborts the whole transaction — gcc
+# never gets installed. Those images already provide /usr/bin/curl.
+dnf_skip_full_curl() {
+  case "${DISTRO:-}:${VERSION:-}" in
+    almalinux:9|rocky:9|amazonlinux:2023) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 install_apt() {
   fix_debian_archive
   if ! apt-get update; then
@@ -84,13 +94,28 @@ install_apt() {
   for pkg in ca-certificates curl wget git gcc g++ python3 unzip zip findutils; do
     try_install "apt ${pkg}" apt-get install -y --no-install-recommends "${pkg}" || true
   done
+  # Ubuntu 20.04's default GCC is 9; Abseil needs GCC 10+.
+  if [[ "${DISTRO:-}" == "ubuntu" && "${VERSION:-}" == "20.04" ]]; then
+    try_install "apt gcc-10" apt-get install -y --no-install-recommends gcc-10 g++-10 || true
+    if command -v gcc-10 >/dev/null 2>&1 && command -v g++-10 >/dev/null 2>&1; then
+      export CC=gcc-10
+      export CXX=g++-10
+      echo "Using CC=${CC} CXX=${CXX} (Ubuntu 20.04)"
+    fi
+  fi
 }
 
 install_dnf_yum() {
   if command -v dnf >/dev/null 2>&1; then
     dnf -y update --refresh || true
-    try_install dnf dnf install -y gcc gcc-c++ python3 git curl ca-certificates unzip zip findutils || \
-      try_install dnf-minimal dnf install -y gcc gcc-c++ python3 git curl ca-certificates unzip zip || true
+    if dnf_skip_full_curl; then
+      echo "Skipping full curl package (${DISTRO} ${VERSION} ships curl-minimal)"
+      try_install dnf dnf install -y gcc gcc-c++ python3 git ca-certificates unzip zip findutils || \
+        try_install dnf-minimal dnf install -y gcc gcc-c++ python3 git ca-certificates unzip zip || true
+    else
+      try_install dnf dnf install -y gcc gcc-c++ python3 git curl ca-certificates unzip zip findutils || \
+        try_install dnf-minimal dnf install -y gcc gcc-c++ python3 git curl ca-certificates unzip zip || true
+    fi
   elif command -v yum >/dev/null 2>&1; then
     yum -y update || true
     try_install yum yum install -y gcc gcc-c++ python3 git curl ca-certificates unzip zip findutils || true
@@ -100,9 +125,23 @@ install_dnf_yum() {
 }
 
 install_zypper() {
-  zypper --non-interactive refresh || true
-  try_install zypper zypper --non-interactive install -y \
-    gcc gcc-c++ python3 git curl ca-certificates unzip zip findutils || true
+  if [[ "${DISTRO:-}" == "opensuse" && "${VERSION:-}" == "15.6" ]]; then
+    # Leap 15.6 default gcc is gcc7 (too old for Abseil). gcc13 is in-tree.
+    # Force-refresh so SLE-update metadata is not stale (that repo 404'd
+    # versioned RPMs such as libatomic1 during the first matrix run).
+    zypper --non-interactive refresh --force || zypper --non-interactive refresh || true
+    try_install zypper zypper --non-interactive install -y \
+      gcc13 gcc13-c++ python3 git curl ca-certificates unzip zip findutils || true
+    if command -v gcc-13 >/dev/null 2>&1 && command -v g++-13 >/dev/null 2>&1; then
+      export CC=gcc-13
+      export CXX=g++-13
+      echo "Using CC=${CC} CXX=${CXX} (openSUSE Leap 15.6)"
+    fi
+  else
+    zypper --non-interactive refresh || true
+    try_install zypper zypper --non-interactive install -y \
+      gcc gcc-c++ python3 git curl ca-certificates unzip zip findutils || true
+  fi
 }
 
 install_apk() {
@@ -131,7 +170,10 @@ else
   echo "WARN: no known package manager"
 fi
 
-if ! command -v gcc >/dev/null 2>&1 && ! command -v cc >/dev/null 2>&1 && ! command -v g++ >/dev/null 2>&1; then
+if ! command -v gcc >/dev/null 2>&1 \
+    && ! command -v cc >/dev/null 2>&1 \
+    && ! command -v g++ >/dev/null 2>&1 \
+    && ! { [[ -n "${CC:-}" ]] && command -v "${CC}" >/dev/null 2>&1; }; then
   echo "ERROR: missing compiler: gcc/g++/cc not installed"
 fi
 
@@ -160,6 +202,21 @@ build --disk_cache=/cache/bazel-disk
 build --repository_cache=/cache/bazel-repo
 build --keep_going
 EOF
+
+# .bazelrc uses --incompatible_strict_action_env; export the pinned
+# toolchain into both repo config and compile actions when set.
+if [[ -n "${CC:-}" ]]; then
+  {
+    echo "build --repo_env=CC=${CC}"
+    echo "build --action_env=CC=${CC}"
+  } >> /tmp/ci.bazelrc
+fi
+if [[ -n "${CXX:-}" ]]; then
+  {
+    echo "build --repo_env=CXX=${CXX}"
+    echo "build --action_env=CXX=${CXX}"
+  } >> /tmp/ci.bazelrc
+fi
 
 echo "=== bazel build //src/Service:OrbitService ==="
 bazel --bazelrc=/tmp/ci.bazelrc build //src/Service:OrbitService

--- a/ci/linux/run-job.sh
+++ b/ci/linux/run-job.sh
@@ -52,7 +52,7 @@ useful_error() {
       grep -E -i \
         'no image:|ERROR: |error: |FATAL: |GLIBC_[0-9]|missing compiler|no Bazel|cannot execute|not found|Cannot connect|debootstrap|failed to solve|permission denied' \
         "${log}" \
-        | grep -v -E '^(Get:|Hit:|Ign:|Fetched |Reading package|Selecting previously|Preparing to unpack|Unpacking |Setting up )' \
+        | grep -v -E -i '^(Get:|Hit:|Ign:|Fetched |Reading package|Selecting previously|Preparing to unpack|Unpacking |Setting up |Error:[[:space:]]*$)' \
         | ${pick} -n 1 || true
     )"
     if [[ -z "${line}" ]]; then

--- a/ci/linux/versions.json
+++ b/ci/linux/versions.json
@@ -302,5 +302,13 @@
     "image": "archlinux:latest",
     "image_alt": "",
     "cache": true
+  },
+  {
+    "distro": "omarchy",
+    "version": "rolling",
+    "codename": "rolling",
+    "image": "archlinux:latest",
+    "image_alt": "",
+    "cache": true
   }
 ]

--- a/ci/linux/versions.json
+++ b/ci/linux/versions.json
@@ -1,38 +1,6 @@
 [
   {
     "distro": "ubuntu",
-    "version": "18.04",
-    "codename": "bionic",
-    "image": "ubuntu:18.04",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "ubuntu",
-    "version": "18.10",
-    "codename": "cosmic",
-    "image": "ubuntu:18.10",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "ubuntu",
-    "version": "19.04",
-    "codename": "disco",
-    "image": "ubuntu:19.04",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "ubuntu",
-    "version": "19.10",
-    "codename": "eoan",
-    "image": "ubuntu:19.10",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "ubuntu",
     "version": "20.04",
     "codename": "focal",
     "image": "ubuntu:20.04",
@@ -137,22 +105,6 @@
   },
   {
     "distro": "debian",
-    "version": "9",
-    "codename": "stretch",
-    "image": "debian:9",
-    "image_alt": "debian:stretch",
-    "cache": false
-  },
-  {
-    "distro": "debian",
-    "version": "10",
-    "codename": "buster",
-    "image": "debian:10",
-    "image_alt": "debian:buster",
-    "cache": false
-  },
-  {
-    "distro": "debian",
     "version": "11",
     "codename": "bullseye",
     "image": "debian:11",
@@ -174,38 +126,6 @@
     "image": "debian:13",
     "image_alt": "debian:trixie",
     "cache": true
-  },
-  {
-    "distro": "fedora",
-    "version": "28",
-    "codename": "f28",
-    "image": "fedora:28",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "fedora",
-    "version": "29",
-    "codename": "f29",
-    "image": "fedora:29",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "fedora",
-    "version": "30",
-    "codename": "f30",
-    "image": "fedora:30",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "fedora",
-    "version": "31",
-    "codename": "f31",
-    "image": "fedora:31",
-    "image_alt": "",
-    "cache": false
   },
   {
     "distro": "fedora",
@@ -313,14 +233,6 @@
   },
   {
     "distro": "rocky",
-    "version": "8",
-    "codename": "greenobsidian",
-    "image": "rockylinux:8",
-    "image_alt": "rockylinux/rockylinux:8",
-    "cache": false
-  },
-  {
-    "distro": "rocky",
     "version": "9",
     "codename": "blueonyx",
     "image": "rockylinux:9",
@@ -337,14 +249,6 @@
   },
   {
     "distro": "almalinux",
-    "version": "8",
-    "codename": "",
-    "image": "almalinux:8",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "almalinux",
     "version": "9",
     "codename": "",
     "image": "almalinux:9",
@@ -356,54 +260,6 @@
     "version": "10",
     "codename": "",
     "image": "almalinux:10",
-    "image_alt": "",
-    "cache": true
-  },
-  {
-    "distro": "opensuse",
-    "version": "15.0",
-    "codename": "leap15.0",
-    "image": "opensuse/leap:15.0",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "opensuse",
-    "version": "15.1",
-    "codename": "leap15.1",
-    "image": "opensuse/leap:15.1",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "opensuse",
-    "version": "15.2",
-    "codename": "leap15.2",
-    "image": "opensuse/leap:15.2",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "opensuse",
-    "version": "15.3",
-    "codename": "leap15.3",
-    "image": "opensuse/leap:15.3",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "opensuse",
-    "version": "15.4",
-    "codename": "leap15.4",
-    "image": "opensuse/leap:15.4",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "opensuse",
-    "version": "15.5",
-    "codename": "leap15.5",
-    "image": "opensuse/leap:15.5",
     "image_alt": "",
     "cache": true
   },
@@ -430,150 +286,6 @@
     "image": "opensuse/tumbleweed:latest",
     "image_alt": "",
     "cache": true
-  },
-  {
-    "distro": "alpine",
-    "version": "3.8",
-    "codename": "v3.8",
-    "image": "alpine:3.8",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "alpine",
-    "version": "3.9",
-    "codename": "v3.9",
-    "image": "alpine:3.9",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "alpine",
-    "version": "3.10",
-    "codename": "v3.10",
-    "image": "alpine:3.10",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "alpine",
-    "version": "3.11",
-    "codename": "v3.11",
-    "image": "alpine:3.11",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "alpine",
-    "version": "3.12",
-    "codename": "v3.12",
-    "image": "alpine:3.12",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "alpine",
-    "version": "3.13",
-    "codename": "v3.13",
-    "image": "alpine:3.13",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "alpine",
-    "version": "3.14",
-    "codename": "v3.14",
-    "image": "alpine:3.14",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "alpine",
-    "version": "3.15",
-    "codename": "v3.15",
-    "image": "alpine:3.15",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "alpine",
-    "version": "3.16",
-    "codename": "v3.16",
-    "image": "alpine:3.16",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "alpine",
-    "version": "3.17",
-    "codename": "v3.17",
-    "image": "alpine:3.17",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "alpine",
-    "version": "3.18",
-    "codename": "v3.18",
-    "image": "alpine:3.18",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "alpine",
-    "version": "3.19",
-    "codename": "v3.19",
-    "image": "alpine:3.19",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "alpine",
-    "version": "3.20",
-    "codename": "v3.20",
-    "image": "alpine:3.20",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "alpine",
-    "version": "3.21",
-    "codename": "v3.21",
-    "image": "alpine:3.21",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "alpine",
-    "version": "3.22",
-    "codename": "v3.22",
-    "image": "alpine:3.22",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "alpine",
-    "version": "3.23",
-    "codename": "v3.23",
-    "image": "alpine:3.23",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "alpine",
-    "version": "3.24",
-    "codename": "v3.24",
-    "image": "alpine:3.24",
-    "image_alt": "",
-    "cache": false
-  },
-  {
-    "distro": "amazonlinux",
-    "version": "2",
-    "codename": "amzn2",
-    "image": "amazonlinux:2",
-    "image_alt": "",
-    "cache": false
   },
   {
     "distro": "amazonlinux",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cuts the nightly `linux-distro-matrix` from 74 cells to 39, based on [linux-distro-matrix #2](https://github.com/pierricgimmig/orbit/actions/runs/32916291262) on `main` @ `0edb1bd` (completed, 36 success / 41 failure), plus a named Omarchy cell.

The six cells still running at the ~6:39 PM PT Aug 25 snapshot all **passed**: ubuntu 22.10, fedora 34, fedora 35, fedora 43, opensuse 16.0, arch rolling. They stay.

## Kept (already green)

- **almalinux** 10
- **debian** 11, 12, 13
- **fedora** 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44
- **rocky** 10
- **ubuntu** 20.10, 21.04, 21.10, 22.04, 22.10, 23.04, 23.10, 24.04, 24.10, 25.04, 25.10, 26.04
- **opensuse** 16.0, tumbleweed
- **arch** rolling

Node 20 deprecation and Bazel-cache `tar` save exit 2 on passing jobs are warnings, not failures.

## Added — Omarchy (Arch-based)

- **omarchy** rolling — [Omarchy](https://omarchy.org/) is DHH’s Arch + Hyprland distro. There is no official Docker image, and this job only needs the userspace (glibc/gcc/linker), not Hyprland. The cell is labeled `omarchy` / `rolling` and uses official `archlinux:latest` (same userspace as **arch rolling**, which stays). Packages go through the existing pacman install path. No Omarchy desktop, installer ISO, or unofficial community images.

## Kept and fixed (easy misses)

Diagnosed from job logs / `ci-result-*` artifacts on that run:

1. **almalinux 9, rocky 9, amazonlinux 2023** — artifact was `"error": "Error: "` because dnf printed a blank `Error:` line. Real cause: `curl-minimal` on the image conflicts with the full `curl` package, so the whole `dnf install gcc … curl` transaction aborted and gcc never installed. Fix: omit `curl` on those three (curl-minimal already provides `/usr/bin/curl`). Also skip empty `Error:` lines in `useful_error`.
2. **ubuntu 20.04** — Abseil `#error "This package requires GCC 10 or higher."` with default GCC 9. Fix: install `gcc-10`/`g++-10` and point Bazel at them via `CC`/`CXX` + `--repo_env`/`--action_env` (needed because `.bazelrc` uses `--incompatible_strict_action_env`).
3. **opensuse 15.6** — artifact showed a SLE-update `libatomic1-…rpm [.not found]` retry; zypper actually finished and installed **gcc7**, then Abseil failed the same GCC 10+ check. Fix: force-refresh repos and install `gcc13`/`gcc13-c++`, pin `CC=gcc-13` / `CXX=g++-13`.

All five stay in the matrix. Install/toolchain changes are gated by distro/version so already-green cells use the same package commands as before.

## Dropped (not easy)

- All **Alpine** 3.8–3.24 — bazelisk glibc binary / musl
- **debian 9** — Bazel needs `GLIBC_2.25`
- **debian 10**, **fedora 28–31**, **ubuntu 18.04**, **almalinux 8**, **rocky 8**, **amazonlinux 2**, **opensuse Leap 15.0–15.5** — Abseil wants GCC 10+
- **ubuntu 18.10 / 19.04 / 19.10** — EOL apt 404s

Nightly schedule, change-detection gate, `workflow_dispatch`, bazelisk pin, and log-streaming are unchanged.

To re-run the matrix on this branch: Actions → linux-distro-matrix → Run workflow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-471351ff-8eb2-480c-9212-373caafd0955?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-471351ff-8eb2-480c-9212-373caafd0955&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

