### PR TITLE
CI: isolate matrix VERSION from /etc/os-release so 20.04 gcc-10 pin runs

### DIFF
--- a/ci/linux/install-and-build.sh
+++ b/ci/linux/install-and-build.sh
@@ -17,6 +17,25 @@ if [[ -f /etc/os-release ]]; then
   cat /etc/os-release
   echo "======================="
 fi
+echo "Matrix DISTRO=${DISTRO:-} VERSION=${VERSION:-} CODENAME=${CODENAME:-}"
+
+# Read one field from /etc/os-release without leaking assignments into this
+# shell. Ubuntu's file sets VERSION="20.04.6 LTS (Focal Fossa)", which would
+# clobber the matrix VERSION=20.04 used to pin compilers.
+os_release_field() {
+  local field="$1"
+  [[ -f /etc/os-release ]] || return 0
+  # shellcheck disable=SC1091
+  (
+    . /etc/os-release
+    case "${field}" in
+      ID) printf '%s' "${ID:-}" ;;
+      VERSION_ID) printf '%s' "${VERSION_ID:-}" ;;
+      VERSION_CODENAME) printf '%s' "${VERSION_CODENAME:-}" ;;
+      *) return 1 ;;
+    esac
+  )
+}
 
 if command -v git >/dev/null 2>&1; then
   git config --global --add safe.directory /workspace || true
@@ -55,11 +74,7 @@ fix_ubuntu_mirrors() {
 
 fix_debian_archive() {
   local code=""
-  if [[ -f /etc/os-release ]]; then
-    # shellcheck disable=SC1091
-    . /etc/os-release
-    code="${VERSION_CODENAME:-}"
-  fi
+  code="$(os_release_field VERSION_CODENAME)"
   case "${code}" in
     stretch|buster)
       echo "deb http://archive.debian.org/debian ${code} main" > /etc/apt/sources.list
@@ -94,13 +109,50 @@ install_apt() {
   for pkg in ca-certificates curl wget git gcc g++ python3 unzip zip findutils; do
     try_install "apt ${pkg}" apt-get install -y --no-install-recommends "${pkg}" || true
   done
-  # Ubuntu 20.04's default GCC is 9; Abseil needs GCC 10+.
-  if [[ "${DISTRO:-}" == "ubuntu" && "${VERSION:-}" == "20.04" ]]; then
-    try_install "apt gcc-10" apt-get install -y --no-install-recommends gcc-10 g++-10 || true
-    if command -v gcc-10 >/dev/null 2>&1 && command -v g++-10 >/dev/null 2>&1; then
-      export CC=gcc-10
-      export CXX=g++-10
-      echo "Using CC=${CC} CXX=${CXX} (Ubuntu 20.04)"
+  # Ubuntu 20.04's default GCC is 9; Abseil needs GCC 10+. Detect from
+  # the matrix env *or* os-release VERSION_ID so a leaked VERSION= from
+  # /etc/os-release cannot skip this pin (that is what failed run #4).
+  if [[ "${DISTRO:-}" == "ubuntu" && "${VERSION:-}" == "20.04" ]] \
+      || { [[ "$(os_release_field ID)" == "ubuntu" ]] \
+           && [[ "$(os_release_field VERSION_ID)" == "20.04" ]]; }; then
+    if ! try_install "apt gcc-10" apt-get install -y --no-install-recommends gcc-10 g++-10; then
+      echo "ERROR: Ubuntu 20.04 needs gcc-10/g++-10 (Abseil requires GCC 10+)"
+      exit 1
+    fi
+    if ! command -v gcc-10 >/dev/null 2>&1 || ! command -v g++-10 >/dev/null 2>&1; then
+      echo "ERROR: gcc-10/g++-10 did not land on PATH"
+      exit 1
+    fi
+    # /usr/bin/gcc is a metapackage symlink to gcc-9, not an alternatives
+    # slave. Bazel 9 + --incompatible_strict_action_env execs /usr/bin/gcc
+    # for both target and [for tool] (exec/host) compiles; --action_env=CC
+    # does not change that. Make the names Bazel actually runs be GCC 10.
+    pin_cc_name() {
+      local name="$1"
+      local bin="$2"
+      local dest="/usr/bin/${name}"
+      if command -v update-alternatives >/dev/null 2>&1; then
+        rm -f "${dest}"
+        if update-alternatives --install "${dest}" "${name}" "${bin}" 100 \
+            && update-alternatives --set "${name}" "${bin}"; then
+          return 0
+        fi
+      fi
+      ln -sfn "${bin}" "${dest}"
+    }
+    pin_cc_name gcc /usr/bin/gcc-10
+    pin_cc_name g++ /usr/bin/g++-10
+    pin_cc_name cc /usr/bin/gcc-10
+    pin_cc_name c++ /usr/bin/g++-10
+    export CC=/usr/bin/gcc-10
+    export CXX=/usr/bin/g++-10
+    local gcc_major=""
+    gcc_major="$(gcc -dumpversion | cut -d. -f1)"
+    echo "Using CC=${CC} CXX=${CXX} (Ubuntu 20.04); /usr/bin/gcc major=${gcc_major}"
+    gcc -v || true
+    if ! [[ "${gcc_major}" =~ ^[0-9]+$ ]] || [[ "${gcc_major}" -lt 10 ]]; then
+      echo "ERROR: /usr/bin/gcc is still GCC ${gcc_major:-unknown}; need 10+"
+      exit 1
     fi
   fi
 }
@@ -203,18 +255,21 @@ build --repository_cache=/cache/bazel-repo
 build --keep_going
 EOF
 
-# .bazelrc uses --incompatible_strict_action_env; export the pinned
-# toolchain into both repo config and compile actions when set.
+# .bazelrc uses --incompatible_strict_action_env. Pin the compiler for
+# repository configuration, target actions, and exec/host ([for tool])
+# actions. --action_env alone does not reach the exec configuration.
 if [[ -n "${CC:-}" ]]; then
   {
     echo "build --repo_env=CC=${CC}"
     echo "build --action_env=CC=${CC}"
+    echo "build --host_action_env=CC=${CC}"
   } >> /tmp/ci.bazelrc
 fi
 if [[ -n "${CXX:-}" ]]; then
   {
     echo "build --repo_env=CXX=${CXX}"
     echo "build --action_env=CXX=${CXX}"
+    echo "build --host_action_env=CXX=${CXX}"
   } >> /tmp/ci.bazelrc
 fi
 

--- a/ci/linux/install-and-build.sh
+++ b/ci/linux/install-and-build.sh
@@ -115,6 +115,14 @@ install_apt() {
   if [[ "${DISTRO:-}" == "ubuntu" && "${VERSION:-}" == "20.04" ]] \
       || { [[ "$(os_release_field ID)" == "ubuntu" ]] \
            && [[ "$(os_release_field VERSION_ID)" == "20.04" ]]; }; then
+    # gcc-10/g++-10 are in universe on Focal (main only has gcc-9).
+    # Official ubuntu:20.04 already enables universe; this covers slim/debootstrap.
+    echo "Ensuring Ubuntu 20.04 universe (needed for gcc-10)"
+    if [[ -f /etc/apt/sources.list ]]; then
+      sed -i -E '/ubuntu\.com\/ubuntu/ { /[[:space:]]universe([[:space:]]|$)/! s/[[:space:]]*$/ universe/ }' \
+        /etc/apt/sources.list
+    fi
+    apt-get update || echo "WARN: apt-get update after enabling universe failed"
     if ! try_install "apt gcc-10" apt-get install -y --no-install-recommends gcc-10 g++-10; then
       echo "ERROR: Ubuntu 20.04 needs gcc-10/g++-10 (Abseil requires GCC 10+)"
       exit 1

--- a/ci/linux/install-and-build.sh
+++ b/ci/linux/install-and-build.sh
@@ -17,25 +17,6 @@ if [[ -f /etc/os-release ]]; then
   cat /etc/os-release
   echo "======================="
 fi
-echo "Matrix DISTRO=${DISTRO:-} VERSION=${VERSION:-} CODENAME=${CODENAME:-}"
-
-# Read one field from /etc/os-release without leaking assignments into this
-# shell. Ubuntu's file sets VERSION="20.04.6 LTS (Focal Fossa)", which would
-# clobber the matrix VERSION=20.04 used to pin compilers.
-os_release_field() {
-  local field="$1"
-  [[ -f /etc/os-release ]] || return 0
-  # shellcheck disable=SC1091
-  (
-    . /etc/os-release
-    case "${field}" in
-      ID) printf '%s' "${ID:-}" ;;
-      VERSION_ID) printf '%s' "${VERSION_ID:-}" ;;
-      VERSION_CODENAME) printf '%s' "${VERSION_CODENAME:-}" ;;
-      *) return 1 ;;
-    esac
-  )
-}
 
 if command -v git >/dev/null 2>&1; then
   git config --global --add safe.directory /workspace || true
@@ -74,7 +55,13 @@ fix_ubuntu_mirrors() {
 
 fix_debian_archive() {
   local code=""
-  code="$(os_release_field VERSION_CODENAME)"
+  if [[ -f /etc/os-release ]]; then
+    # Source in a subshell. /etc/os-release assigns VERSION=
+    # ("20.04.6 LTS (Focal Fossa)"), which must not clobber the
+    # matrix VERSION=20.04 used to pin GCC 10.
+    # shellcheck disable=SC1091
+    code="$(. /etc/os-release && printf '%s' "${VERSION_CODENAME:-}")"
+  fi
   case "${code}" in
     stretch|buster)
       echo "deb http://archive.debian.org/debian ${code} main" > /etc/apt/sources.list
@@ -109,58 +96,13 @@ install_apt() {
   for pkg in ca-certificates curl wget git gcc g++ python3 unzip zip findutils; do
     try_install "apt ${pkg}" apt-get install -y --no-install-recommends "${pkg}" || true
   done
-  # Ubuntu 20.04's default GCC is 9; Abseil needs GCC 10+. Detect from
-  # the matrix env *or* os-release VERSION_ID so a leaked VERSION= from
-  # /etc/os-release cannot skip this pin (that is what failed run #4).
-  if [[ "${DISTRO:-}" == "ubuntu" && "${VERSION:-}" == "20.04" ]] \
-      || { [[ "$(os_release_field ID)" == "ubuntu" ]] \
-           && [[ "$(os_release_field VERSION_ID)" == "20.04" ]]; }; then
-    # gcc-10/g++-10 are in universe on Focal (main only has gcc-9).
-    # Official ubuntu:20.04 already enables universe; this covers slim/debootstrap.
-    echo "Ensuring Ubuntu 20.04 universe (needed for gcc-10)"
-    if [[ -f /etc/apt/sources.list ]]; then
-      sed -i -E '/ubuntu\.com\/ubuntu/ { /[[:space:]]universe([[:space:]]|$)/! s/[[:space:]]*$/ universe/ }' \
-        /etc/apt/sources.list
-    fi
-    apt-get update || echo "WARN: apt-get update after enabling universe failed"
-    if ! try_install "apt gcc-10" apt-get install -y --no-install-recommends gcc-10 g++-10; then
-      echo "ERROR: Ubuntu 20.04 needs gcc-10/g++-10 (Abseil requires GCC 10+)"
-      exit 1
-    fi
-    if ! command -v gcc-10 >/dev/null 2>&1 || ! command -v g++-10 >/dev/null 2>&1; then
-      echo "ERROR: gcc-10/g++-10 did not land on PATH"
-      exit 1
-    fi
-    # /usr/bin/gcc is a metapackage symlink to gcc-9, not an alternatives
-    # slave. Bazel 9 + --incompatible_strict_action_env execs /usr/bin/gcc
-    # for both target and [for tool] (exec/host) compiles; --action_env=CC
-    # does not change that. Make the names Bazel actually runs be GCC 10.
-    pin_cc_name() {
-      local name="$1"
-      local bin="$2"
-      local dest="/usr/bin/${name}"
-      if command -v update-alternatives >/dev/null 2>&1; then
-        rm -f "${dest}"
-        if update-alternatives --install "${dest}" "${name}" "${bin}" 100 \
-            && update-alternatives --set "${name}" "${bin}"; then
-          return 0
-        fi
-      fi
-      ln -sfn "${bin}" "${dest}"
-    }
-    pin_cc_name gcc /usr/bin/gcc-10
-    pin_cc_name g++ /usr/bin/g++-10
-    pin_cc_name cc /usr/bin/gcc-10
-    pin_cc_name c++ /usr/bin/g++-10
-    export CC=/usr/bin/gcc-10
-    export CXX=/usr/bin/g++-10
-    local gcc_major=""
-    gcc_major="$(gcc -dumpversion | cut -d. -f1)"
-    echo "Using CC=${CC} CXX=${CXX} (Ubuntu 20.04); /usr/bin/gcc major=${gcc_major}"
-    gcc -v || true
-    if ! [[ "${gcc_major}" =~ ^[0-9]+$ ]] || [[ "${gcc_major}" -lt 10 ]]; then
-      echo "ERROR: /usr/bin/gcc is still GCC ${gcc_major:-unknown}; need 10+"
-      exit 1
+  # Ubuntu 20.04's default GCC is 9; Abseil needs GCC 10+.
+  if [[ "${DISTRO:-}" == "ubuntu" && "${VERSION:-}" == "20.04" ]]; then
+    try_install "apt gcc-10" apt-get install -y --no-install-recommends gcc-10 g++-10 || true
+    if command -v gcc-10 >/dev/null 2>&1 && command -v g++-10 >/dev/null 2>&1; then
+      export CC=gcc-10
+      export CXX=g++-10
+      echo "Using CC=${CC} CXX=${CXX} (Ubuntu 20.04)"
     fi
   fi
 }
@@ -263,21 +205,18 @@ build --repository_cache=/cache/bazel-repo
 build --keep_going
 EOF
 
-# .bazelrc uses --incompatible_strict_action_env. Pin the compiler for
-# repository configuration, target actions, and exec/host ([for tool])
-# actions. --action_env alone does not reach the exec configuration.
+# .bazelrc uses --incompatible_strict_action_env; export the pinned
+# toolchain into both repo config and compile actions when set.
 if [[ -n "${CC:-}" ]]; then
   {
     echo "build --repo_env=CC=${CC}"
     echo "build --action_env=CC=${CC}"
-    echo "build --host_action_env=CC=${CC}"
   } >> /tmp/ci.bazelrc
 fi
 if [[ -n "${CXX:-}" ]]; then
   {
     echo "build --repo_env=CXX=${CXX}"
     echo "build --action_env=CXX=${CXX}"
-    echo "build --host_action_env=CXX=${CXX}"
   } >> /tmp/ci.bazelrc
 fi
 

--- a/ci/linux/run-job.sh
+++ b/ci/linux/run-job.sh
@@ -48,18 +48,13 @@ useful_error() {
   fi
   local line=""
   if [[ -f "${log}" ]]; then
-    # Prefer a compiler #error (Abseil "requires GCC 10+") over Bazel's
-    # wrapping "ERROR: … gcc failed: error executing CppCompile command (".
-    line="$(grep -E '#error' "${log}" | ${pick} -n 1 || true)"
-    if [[ -z "${line}" ]]; then
-      line="$(
-        grep -E -i \
-          'no image:|ERROR: |error: |FATAL: |GLIBC_[0-9]|missing compiler|no Bazel|cannot execute|not found|Cannot connect|debootstrap|failed to solve|permission denied' \
-          "${log}" \
-          | grep -v -E -i '^(Get:|Hit:|Ign:|Fetched |Reading package|Selecting previously|Preparing to unpack|Unpacking |Setting up |Error:[[:space:]]*$)' \
-          | ${pick} -n 1 || true
-      )"
-    fi
+    line="$(
+      grep -E -i \
+        'no image:|ERROR: |error: |FATAL: |GLIBC_[0-9]|missing compiler|no Bazel|cannot execute|not found|Cannot connect|debootstrap|failed to solve|permission denied' \
+        "${log}" \
+        | grep -v -E -i '^(Get:|Hit:|Ign:|Fetched |Reading package|Selecting previously|Preparing to unpack|Unpacking |Setting up |Error:[[:space:]]*$)' \
+        | ${pick} -n 1 || true
+    )"
     if [[ -z "${line}" ]]; then
       line="$(grep -E -i 'error|fail|fatal' "${log}" | tail -n 1 || true)"
     fi

--- a/ci/linux/run-job.sh
+++ b/ci/linux/run-job.sh
@@ -48,13 +48,18 @@ useful_error() {
   fi
   local line=""
   if [[ -f "${log}" ]]; then
-    line="$(
-      grep -E -i \
-        'no image:|ERROR: |error: |FATAL: |GLIBC_[0-9]|missing compiler|no Bazel|cannot execute|not found|Cannot connect|debootstrap|failed to solve|permission denied' \
-        "${log}" \
-        | grep -v -E -i '^(Get:|Hit:|Ign:|Fetched |Reading package|Selecting previously|Preparing to unpack|Unpacking |Setting up |Error:[[:space:]]*$)' \
-        | ${pick} -n 1 || true
-    )"
+    # Prefer a compiler #error (Abseil "requires GCC 10+") over Bazel's
+    # wrapping "ERROR: … gcc failed: error executing CppCompile command (".
+    line="$(grep -E '#error' "${log}" | ${pick} -n 1 || true)"
+    if [[ -z "${line}" ]]; then
+      line="$(
+        grep -E -i \
+          'no image:|ERROR: |error: |FATAL: |GLIBC_[0-9]|missing compiler|no Bazel|cannot execute|not found|Cannot connect|debootstrap|failed to solve|permission denied' \
+          "${log}" \
+          | grep -v -E -i '^(Get:|Hit:|Ign:|Fetched |Reading package|Selecting previously|Preparing to unpack|Unpacking |Setting up |Error:[[:space:]]*$)' \
+          | ${pick} -n 1 || true
+      )"
+    fi
     if [[ -z "${line}" ]]; then
       line="$(grep -E -i 'error|fail|fatal' "${log}" | tail -n 1 || true)"
     fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## One-line fix

`fix_debian_archive` sourced `/etc/os-release` in the guest shell. Focal sets `VERSION="20.04.6 LTS (Focal Fossa)"`, which overwrote the matrix `VERSION=20.04` and skipped the existing gcc-10 pin from #28.

Read `VERSION_CODENAME` in a subshell so `VERSION` / `DISTRO` stay as the matrix passed them.

## Why #4 failed

[linux-distro-matrix run 32977076879](https://github.com/pierricgimmig/orbit/actions/runs/32977076879), ubuntu 20.04:

```
#error "This package requires GCC 10 or higher."
```

gcc-10 was never installed: after `OK: apt findutils` the guest went to Bazelisk. The PR 28 block (`try_install gcc-10`, `CC=gcc-10`, `--repo_env` / `--action_env`) never ran.

## What this PR does not change

The gcc-10 install + `CC`/`CXX` + `--repo_env`/`--action_env` block stays as it is on main. No universe, no `update-alternatives`, no `--host_action_env`, no `run-job.sh` scraper.

`git diff main` is a few lines in `fix_debian_archive` only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24fa11b0-d7d9-4ab3-8bac-ee28603cb3c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24fa11b0-d7d9-4ab3-8bac-ee28603cb3c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

